### PR TITLE
#20/feature/common textarea/lee

### DIFF
--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -2,15 +2,19 @@ import { ComponentProps } from 'react';
 
 interface TextareaProps extends ComponentProps<'textarea'> {
   label?: string;
-  limit?: number;
+  textCountLimit?: number;
 }
 
-const Textarea = ({ label, limit, ...props }: TextareaProps) => {
+const Textarea = ({
+  label,
+  textCountLimit: limit,
+  ...props
+}: TextareaProps) => {
   return (
     <div className='flex flex-col'>
-      <div className='flex items-center text-gray-700'>
+      <div className='flex items-center justify-between text-gray-700'>
         {label && (
-          <label style={{ marginRight: '260px' }}>
+          <label>
             {label}
             <span className='ml-0.5 text-red-500'>*</span>
           </label>
@@ -21,7 +25,7 @@ const Textarea = ({ label, limit, ...props }: TextareaProps) => {
       </div>
       <div className='relative'>
         <textarea
-          className='h-[180px] w-[358px] resize-none overscroll-contain rounded-lg border-2 border-gray-200 outline-none focus:border-violet-500'
+          className='h-[180px] w-full resize-none overscroll-contain rounded-lg border-2 border-gray-200 outline-none focus:border-violet-500'
           {...props}
         />
       </div>

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -1,0 +1,32 @@
+import { ComponentProps } from 'react';
+
+interface TextareaProps extends ComponentProps<'textarea'> {
+  label?: string;
+  limit?: number;
+}
+
+const Textarea = ({ label, limit, ...props }: TextareaProps) => {
+  return (
+    <div className='flex flex-col'>
+      <div className='flex items-center text-gray-700'>
+        {label && (
+          <label style={{ marginRight: '260px' }}>
+            {label}
+            <span className='ml-0.5 text-red-500'>*</span>
+          </label>
+        )}
+        <span className='text-sm text-gray-400'>
+          {limit && <label>{limit}</label>}/500자
+        </span>
+      </div>
+      <div className='relative'>
+        <textarea
+          className='h-[180px] w-[358px] resize-none overscroll-contain rounded-lg border-2 border-gray-200 outline-none focus:border-violet-500'
+          {...props}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Textarea;

--- a/src/stories/components/TextArea.stories.tsx
+++ b/src/stories/components/TextArea.stories.tsx
@@ -17,12 +17,4 @@ export const Default: Story = {
     label: 'label',
     textCountLimit: 0,
   },
-
-  render: args => {
-    return (
-      <>
-        <Textarea {...args} />
-      </>
-    );
-  },
 };

--- a/src/stories/components/TextArea.stories.tsx
+++ b/src/stories/components/TextArea.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { HttpResponse, http } from 'msw';
 
 import Textarea from '@/components/TextArea/index';
 
@@ -7,13 +6,6 @@ const meta: Meta<typeof Textarea> = {
   title: 'Components/Textarea',
   tags: ['autodocs'],
   component: Textarea,
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('/api/echo', () => HttpResponse.json('hello from server')),
-      ],
-    },
-  },
 };
 
 export default meta;
@@ -23,23 +15,9 @@ type Story = StoryObj<typeof Textarea>;
 export const Default: Story = {
   args: {
     label: 'label',
-    limit: 0,
+    textCountLimit: 0,
   },
-  //   argTypes: {
-  //     size: {
-  //       control: 'radio',
-  //       options: ['sm', 'lg'],
-  //     },
-  //     placeholder: {
-  //       control: 'text',
-  //     },
-  //     label: {
-  //       control: 'text',
-  //     },
-  //     limit: {
-  //       control: 'number',
-  //     },
-  //   },
+
   render: args => {
     return (
       <>

--- a/src/stories/components/TextArea.stories.tsx
+++ b/src/stories/components/TextArea.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { HttpResponse, http } from 'msw';
+
+import Textarea from '@/components/TextArea/index';
+
+const meta: Meta<typeof Textarea> = {
+  title: 'Components/Textarea',
+  tags: ['autodocs'],
+  component: Textarea,
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/echo', () => HttpResponse.json('hello from server')),
+      ],
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Textarea>;
+
+export const Default: Story = {
+  args: {
+    label: 'label',
+    limit: 0,
+  },
+  //   argTypes: {
+  //     size: {
+  //       control: 'radio',
+  //       options: ['sm', 'lg'],
+  //     },
+  //     placeholder: {
+  //       control: 'text',
+  //     },
+  //     label: {
+  //       control: 'text',
+  //     },
+  //     limit: {
+  //       control: 'number',
+  //     },
+  //   },
+  render: args => {
+    return (
+      <>
+        <Textarea {...args} />
+      </>
+    );
+  },
+};


### PR DESCRIPTION
## 💬 Issue Number

> closes #20 

## 🤷‍♂️ Description

> TextArea 공통 컴포넌트를 구현하였습니다.

## 📷 Screenshots

> <img width="1203" alt="스크린샷 2024-02-16 오전 9 51 08" src="https://github.com/BoardSignal/Team-CivilWar-BoardSignal-FE/assets/99376069/b7e538f8-aa4c-430f-8acc-29929543c96c">

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 📒 Remarks
> - 잘못된 코드가 있다면 알려주세요.
> - 색상 적용을 할 때 `border-primary`, `border-gray-accent-1`이렇게 지정된 색을 적용하고 저장하면 자동으로 코드들이 맨 앞으로 빠져서 커밋 시 husky 에러가 나서 `border-violet-500`로 적용해두었습니다.
