### PR TITLE
[#32] Fix: Button의 Ripple의 사용 방식 변경 및 ghost variant 추가

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -18,6 +18,9 @@ const buttonCSS = cva(
         inactive: 'cursor-not-allowed bg-gray-accent5 text-gray-accent3',
       },
     },
+    defaultVariants: {
+      variant: 'ghost',
+    },
   },
 );
 

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,33 +1,39 @@
-import { ButtonHTMLAttributes } from 'react';
+import { ComponentProps } from 'react';
 
 import { type VariantProps, cva } from 'class-variance-authority';
 
+import { cn } from '@/utils/cn';
+
 import Ripple from '../Ripple';
 
-const buttonCSS = cva('h-10 w-full rounded-lg', {
-  variants: {
-    variant: {
-      primary: 'bg-primary text-white',
-      outline: 'border border-gray-accent5 text-gray-accent3',
-      danger: 'border border-red-500 text-red-500',
-      inactive: 'cursor-not-allowed bg-gray-accent5 text-gray-accent3',
+const buttonCSS = cva(
+  'flex h-10 w-full cursor-pointer items-center justify-center rounded-lg',
+  {
+    variants: {
+      variant: {
+        primary: 'bg-primary text-white',
+        outline: 'border border-gray-accent5 text-gray-accent3',
+        ghost: 'text-gray-accent2',
+        danger: 'border border-red-500 text-red-500',
+        inactive: 'cursor-not-allowed bg-gray-accent5 text-gray-accent3',
+      },
     },
   },
-});
+);
 
-interface ButtonProps
-  extends ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonCSS> {}
+type ButtonProps = ComponentProps<'div'> & VariantProps<typeof buttonCSS>;
 
-const Button = ({ variant, ...props }: ButtonProps) => {
+const Button = ({ variant, className, ...props }: ButtonProps) => {
   return (
-    <Ripple>
-      <button
-        disabled={variant === 'inactive'}
-        className={buttonCSS({ variant })}
-        {...props}
-      />
-    </Ripple>
+    <Ripple
+      role='button'
+      className={cn(
+        buttonCSS({ variant }),
+        variant === 'inactive' && 'pointer-events-none',
+        className,
+      )}
+      {...props}
+    />
   );
 };
 

--- a/src/components/GNB/index.tsx
+++ b/src/components/GNB/index.tsx
@@ -11,10 +11,7 @@ export const GNB = () => {
     <div className='flex select-none border-t border-gray-200'>
       {GNBRoutes.map(({ name, path, icons }) => (
         <Link to={path} key={path} className='flex-1'>
-          <Button
-            variant='ghost'
-            className='flex h-fit flex-col items-center gap-0.5 pb-2 pt-4'
-          >
+          <Button className='flex h-fit flex-col items-center gap-0.5 pb-2 pt-4'>
             <Icon
               id={icons[pathname === path ? 'fill' : 'line']}
               className='h-5 w-5 text-gray-accent1'

--- a/src/components/GNB/index.tsx
+++ b/src/components/GNB/index.tsx
@@ -11,15 +11,13 @@ export const GNB = () => {
     <div className='flex select-none border-t border-gray-200'>
       {GNBRoutes.map(({ name, path, icons }) => (
         <Link to={path} key={path} className='flex-1'>
-          <Ripple fast>
-            <div className='flex flex-col items-center gap-0.5 pt-4'>
-              <Icon
-                id={icons[pathname === path ? 'fill' : 'line']}
-                className='h-5 w-5 text-gray-accent1'
-              />
-              <div className='px-2 pb-2 text-[10px] text-gray-accent1'>
-                {name}
-              </div>
+          <Ripple fast className='flex flex-col items-center gap-0.5 pt-4'>
+            <Icon
+              id={icons[pathname === path ? 'fill' : 'line']}
+              className='h-5 w-5 text-gray-accent1'
+            />
+            <div className='px-2 pb-2 text-[10px] text-gray-accent1'>
+              {name}
             </div>
           </Ripple>
         </Link>

--- a/src/components/GNB/index.tsx
+++ b/src/components/GNB/index.tsx
@@ -1,7 +1,7 @@
 import { Link, useLocation } from 'react-router-dom';
 
+import Button from '../Button';
 import Icon from '../Icon';
-import Ripple from '../Ripple';
 import { GNBRoutes } from './routes';
 
 export const GNB = () => {
@@ -11,15 +11,16 @@ export const GNB = () => {
     <div className='flex select-none border-t border-gray-200'>
       {GNBRoutes.map(({ name, path, icons }) => (
         <Link to={path} key={path} className='flex-1'>
-          <Ripple fast className='flex flex-col items-center gap-0.5 pt-4'>
+          <Button
+            variant='ghost'
+            className='flex h-fit flex-col items-center gap-0.5 pb-2 pt-4'
+          >
             <Icon
               id={icons[pathname === path ? 'fill' : 'line']}
               className='h-5 w-5 text-gray-accent1'
             />
-            <div className='px-2 pb-2 text-[10px] text-gray-accent1'>
-              {name}
-            </div>
-          </Ripple>
+            <div className='text-[10px] text-gray-accent1'>{name}</div>
+          </Button>
         </Link>
       ))}
     </div>

--- a/src/components/Ripple/index.tsx
+++ b/src/components/Ripple/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useRef, useState } from 'react';
+import React, { ComponentProps, useRef, useState } from 'react';
 
 import { cn } from '@/utils/cn';
 
@@ -25,8 +25,7 @@ const getOffset = (e: React.MouseEvent<HTMLDivElement>, el: HTMLDivElement) => {
   };
 };
 
-interface RippleProps extends PropsWithChildren {
-  className?: string;
+interface RippleProps extends ComponentProps<'div'> {
   fast?: boolean;
 }
 
@@ -37,7 +36,13 @@ interface RippleProps extends PropsWithChildren {
  *
  * fast={true}로 설정하면 빠른 Ripple 효과를 렌더링할 수 있어요.
  */
-const Ripple = ({ fast, className, children }: RippleProps) => {
+const Ripple = ({
+  fast,
+  className,
+  onClick,
+  children,
+  ...props
+}: RippleProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const [isAnimating, setIsAnimating] = useState(false);
   const [offset, setOffset] = useState(RIPPLE_DEFAULT_OFFSET);
@@ -45,6 +50,10 @@ const Ripple = ({ fast, className, children }: RippleProps) => {
   const showRipple = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!ref.current) {
       return;
+    }
+
+    if (onClick) {
+      onClick(e);
     }
 
     const element = ref.current;
@@ -66,6 +75,7 @@ const Ripple = ({ fast, className, children }: RippleProps) => {
       className={cn('relative overflow-hidden', className)}
       ref={ref}
       onClick={showRipple}
+      {...props}
     >
       {isAnimating && <RippleEffect {...offset} />}
       {children}

--- a/src/stories/components/Button.stories.tsx
+++ b/src/stories/components/Button.stories.tsx
@@ -19,7 +19,15 @@ export default meta;
 
 type Story = StoryObj<typeof Button>;
 
-export const DefaultTemplate: Story = {
+export const DefaultGhost: Story = {
+  name: '기본 버튼(Ghost)',
+  args: {
+    children: '회원가입 없이 둘러보기',
+  },
+};
+
+export const Primary: Story = {
+  name: 'Primary 버튼',
   args: {
     children: '리뷰 제출하기',
     variant: 'primary',


### PR DESCRIPTION
resolves #32

## 🤷‍♂️ Description

버튼 스타일을 커스터마이징할 때 이중으로 수정해야 하는 문제를 해결해요

- [x] 버튼에서 Ripple에 곧장 스타일링을 하고 기본 button이 제공하는 CSS를 추가하기
- [x] ghost variant 추가 (`<Button variant='ghost'>...</Button>`)

## 📷 Screenshots

로그인 페이지 ghost 버튼 적용 예시
- ghost 버튼은 border가 없는 버튼이에요.
- img를 표시하는 경우에도 가능해요.

![image](https://github.com/BoardSignal/Team-CivilWar-BoardSignal-FE/assets/28754907/6c96d71f-a35b-4cca-b975-d428f34554f6)

## 📒 Remarks

- Button을 `button` 대신 `div`로 렌더링하고, 이에 따라 `aria-role: button`을 추가했어요.