### PR TITLE
[#56] Style: 로그인 페이지 추가 퍼블리싱

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -29,10 +29,10 @@ export const router = createBrowserRouter([
         path: 'me',
         element: <HomePage />,
       },
+      {
+        path: 'login',
+        element: <LoginPage />,
+      },
     ],
-  },
-  {
-    path: 'login',
-    element: <LoginPage />,
   },
 ]);

--- a/src/components/TabBar/index.tsx
+++ b/src/components/TabBar/index.tsx
@@ -28,7 +28,7 @@ const Container = ({ children: rawChildren }: PropsWithChildren) => {
   const [leftChildren, rightChildren] = Children.toArray(rawChildren);
 
   return (
-    <div className='flex justify-between p-2 text-gray-accent1'>
+    <div className='border-gray-accent-7 flex justify-between border-b p-2 text-gray-accent1'>
       {leftChildren}
       {rightChildren}
     </div>

--- a/src/pages/Login/components/LoginButtons.tsx
+++ b/src/pages/Login/components/LoginButtons.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import kakaoLoginButtonImage from '@/assets/kakao-login-button.png';
 import Button from '@/components/Button';
@@ -30,18 +30,11 @@ export const NaverLoginButton = () => {
 };
 
 export const SkipLoginButton = () => {
-  const navigate = useNavigate();
-
-  // Ripple 효과가 나오기 전에 이동이 되어서 setTimeout을 사용해요.
-  const goToMain = () => {
-    setTimeout(() => {
-      navigate('/');
-    }, 200);
-  };
-
   return (
-    <Button onClick={goToMain} className={KAKAO_LOGIN_BUTTON_HEIGHT}>
-      회원가입 없이 둘러보기
-    </Button>
+    <Link to='/' className='w-full'>
+      <Button className={KAKAO_LOGIN_BUTTON_HEIGHT}>
+        회원가입 없이 둘러보기
+      </Button>
+    </Link>
   );
 };

--- a/src/pages/Login/components/LoginButtons.tsx
+++ b/src/pages/Login/components/LoginButtons.tsx
@@ -6,11 +6,14 @@ import Button from '@/components/Button';
 import { useKakaoLogin } from '../hooks/useKakaoLogin';
 import { useNaverLogin } from '../hooks/useNaverLogin';
 
+// 63px로 높이를 지정하는 이유는 원본 이미지의 크기가 그렇기 때문이에요.
+const KAKAO_LOGIN_BUTTON_HEIGHT = 'h-[63px]';
+
 export const KakaoLoginButton = () => {
   const { kakaoLogin } = useKakaoLogin();
 
   return (
-    <Button onClick={kakaoLogin}>
+    <Button onClick={kakaoLogin} className={KAKAO_LOGIN_BUTTON_HEIGHT}>
       <img src={kakaoLoginButtonImage} alt='네이버 로그인 버튼' />
     </Button>
   );
@@ -20,7 +23,7 @@ export const NaverLoginButton = () => {
   const { naverLogin } = useNaverLogin();
 
   return (
-    <Button onClick={naverLogin}>
+    <Button onClick={naverLogin} className={KAKAO_LOGIN_BUTTON_HEIGHT}>
       <img src={kakaoLoginButtonImage} alt='카카오 로그인 버튼' />
     </Button>
   );
@@ -36,5 +39,9 @@ export const SkipLoginButton = () => {
     }, 200);
   };
 
-  return <Button onClick={goToMain}>회원가입 없이 둘러보기</Button>;
+  return (
+    <Button onClick={goToMain} className={KAKAO_LOGIN_BUTTON_HEIGHT}>
+      회원가입 없이 둘러보기
+    </Button>
+  );
 };

--- a/src/pages/Login/components/LoginButtons.tsx
+++ b/src/pages/Login/components/LoginButtons.tsx
@@ -6,8 +6,8 @@ import Button from '@/components/Button';
 import { useKakaoLogin } from '../hooks/useKakaoLogin';
 import { useNaverLogin } from '../hooks/useNaverLogin';
 
-// 63px로 높이를 지정하는 이유는 원본 이미지의 크기가 그렇기 때문이에요.
-const KAKAO_LOGIN_BUTTON_HEIGHT = 'h-[63px]';
+// 53.7px로 높이를 지정하는 이유는 원본 이미지의 크기가 그렇기 때문이에요.
+const KAKAO_LOGIN_BUTTON_HEIGHT = 'h-[53.7px]';
 
 export const KakaoLoginButton = () => {
   const { kakaoLogin } = useKakaoLogin();

--- a/src/pages/Login/components/LoginButtons.tsx
+++ b/src/pages/Login/components/LoginButtons.tsx
@@ -1,0 +1,40 @@
+import { useNavigate } from 'react-router-dom';
+
+import kakaoLoginButtonImage from '@/assets/kakao-login-button.png';
+import Button from '@/components/Button';
+
+import { useKakaoLogin } from '../hooks/useKakaoLogin';
+import { useNaverLogin } from '../hooks/useNaverLogin';
+
+export const KakaoLoginButton = () => {
+  const { kakaoLogin } = useKakaoLogin();
+
+  return (
+    <Button onClick={kakaoLogin}>
+      <img src={kakaoLoginButtonImage} alt='네이버 로그인 버튼' />
+    </Button>
+  );
+};
+
+export const NaverLoginButton = () => {
+  const { naverLogin } = useNaverLogin();
+
+  return (
+    <Button onClick={naverLogin}>
+      <img src={kakaoLoginButtonImage} alt='카카오 로그인 버튼' />
+    </Button>
+  );
+};
+
+export const SkipLoginButton = () => {
+  const navigate = useNavigate();
+
+  // Ripple 효과가 나오기 전에 이동이 되어서 setTimeout을 사용해요.
+  const goToMain = () => {
+    setTimeout(() => {
+      navigate('/');
+    }, 200);
+  };
+
+  return <Button onClick={goToMain}>회원가입 없이 둘러보기</Button>;
+};

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,29 +1,35 @@
-import kakaoLoginButtonImage from '@/assets/kakao-login-button.png';
+import logoImage from '@/assets/logo.png';
+import TabBar from '@/components/TabBar';
 
-import { useKakaoLogin } from './hooks/useKakaoLogin';
-import { useNaverLogin } from './hooks/useNaverLogin';
+import {
+  KakaoLoginButton,
+  NaverLoginButton,
+  SkipLoginButton,
+} from './components/LoginButtons';
+
+const SLOGAN_MESSAGE1 = '"매치업! 보드게임을 즐기는';
+const SLOGAN_MESSAGE2 = '사람들을 찾는 최적의 장소."';
 
 const LoginPage = () => {
-  const { kakaoLogin } = useKakaoLogin();
-  const { naverLogin } = useNaverLogin();
-
   return (
-    <>
-      <h1>Login Page</h1>
-      <div className='absolute bottom-[10px] mx-10 flex flex-col items-center justify-center gap-[10px]'>
-        <button className='h-full w-full' onClick={naverLogin}>
-          <img src={kakaoLoginButtonImage} alt='kakao' />
-        </button>
-        <button onClick={kakaoLogin} className='h-full w-full'>
-          <img
-            src={kakaoLoginButtonImage}
-            alt='naver'
-            className='h-[100%] w-[100%]'
-          />
-        </button>
-        <h1 className='my-4 cursor-pointer'>회원가입 없이 둘러보기</h1>
+    <div className='flex h-full flex-col'>
+      <TabBar.Container>
+        <TabBar.GoBackButton />
+      </TabBar.Container>
+      <div className='flex h-full flex-col items-center justify-center gap-2'>
+        <img src={logoImage} alt='보드시그널 로고' />
+        <div>
+          <p className='text-primary'>{SLOGAN_MESSAGE1}</p>
+          <p className='text-primary'>{SLOGAN_MESSAGE2}</p>
+        </div>
       </div>
-    </>
+      <div className='flex flex-col gap-2 p-4'>
+        <NaverLoginButton />
+        <KakaoLoginButton />
+        <SkipLoginButton />
+      </div>
+    </div>
   );
 };
+
 export default LoginPage;

--- a/src/stories/pages/LoginPage.stories.tsx
+++ b/src/stories/pages/LoginPage.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import LoginPage from '@/pages/Login';
+
+const meta: Meta<typeof LoginPage> = {
+  title: 'pages/LoginPage',
+  tags: ['autodocs'],
+  component: LoginPage,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LoginPage>;
+
+export const DefaultTemplate: Story = {};

--- a/src/stories/pages/LoginPage.stories.tsx
+++ b/src/stories/pages/LoginPage.stories.tsx
@@ -2,9 +2,12 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import LoginPage from '@/pages/Login';
 
+import { CommonPageLayoutDecorator } from '../CommonPageLayoutDecorator';
+
 const meta: Meta<typeof LoginPage> = {
   title: 'pages/LoginPage',
   tags: ['autodocs'],
+  decorators: [CommonPageLayoutDecorator],
   component: LoginPage,
 };
 


### PR DESCRIPTION
resolves #56

## 🤷‍♂️ Description

- [x]  기존 로그인 페이지에서 탭바, 버튼, 로고 이미지를 적용했어요.
- [x] 로그인 페이지의 Story를 추가했어요.
- [x] 라우팅 시 레이아웃이 렌더링 안 되는 문제를 해결했어요.

기타 작업

- [x] TabBar의 기본 스타일에 bottom border가 빠져 있어서 추가했어요
- [x] HomePage(예시)의 Story 위치를 pages 밑으로 이동했어요

## 📷 Screenshots

<img src="https://github.com/BoardSignal/Team-CivilWar-BoardSignal-FE/assets/28754907/cd8f45da-c746-4397-a243-53ef0ff2fb50" width=600 />


## 📒 Remarks

- Ripple 효과가 있는 버튼에서 navigate를 할 때는 효과가 보여줄 수 없더라고요. 
  - 어떻게 하면 좋을까요? 지금은 사용처에서 setTimeout으로 handler 실행을 연기하고 있어요.

<b><u> ->페이지 트랜지션이 추가되면 해결되는 문제입니다!</u></b>