### PR TITLE
[#40] Feat: 공통컴포넌트 - Range

### DIFF
--- a/src/components/Range/index.tsx
+++ b/src/components/Range/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent } from 'react';
 
 import { cn } from '@/utils/cn';
 
@@ -19,10 +19,7 @@ const Range = ({
   includedValue,
   onChange,
 }: RangeProps) => {
-  const [from, to] = value;
-
-  const [minValue, setMinValue] = useState(from);
-  const [maxValue, setMaxValue] = useState(to);
+  const [minValue, maxValue] = value;
 
   const range = max - min;
 
@@ -39,7 +36,6 @@ const Range = ({
     }
 
     const nextMinValue = Math.min(maxValue, inputValue);
-    setMinValue(nextMinValue);
 
     onChange([nextMinValue, maxValue]);
   };
@@ -53,7 +49,6 @@ const Range = ({
 
     const nextMaxValue = Math.max(minValue, inputValue);
 
-    setMaxValue(nextMaxValue);
     onChange([minValue, nextMaxValue]);
   };
 

--- a/src/components/Range/index.tsx
+++ b/src/components/Range/index.tsx
@@ -1,0 +1,107 @@
+import { ChangeEvent, useState } from 'react';
+
+interface RangeProps {
+  min: number;
+  max: number;
+  step: number;
+  defaultValue: number[];
+  includedValue?: number;
+  onChange: (value: number[]) => void;
+}
+
+const Range = ({
+  min,
+  max,
+  step,
+  defaultValue = [min, max],
+  includedValue,
+  onChange,
+}: RangeProps) => {
+  const [from, to] = defaultValue;
+
+  const [minValue, setMinValue] = useState(from);
+  const [maxValue, setMaxValue] = useState(to);
+
+  const range = max - min;
+
+  const ticks = Array.from(
+    { length: Math.floor(range / step) + 1 },
+    (_, i) => min + step * i,
+  );
+
+  const handleMinThumb = (e: ChangeEvent<HTMLInputElement>) => {
+    if (includedValue && parseInt(e.target.value) > includedValue) {
+      return;
+    }
+
+    if (parseInt(e.target.value) > maxValue) {
+      setMinValue(maxValue);
+    } else {
+      setMinValue(parseInt(e.target.value));
+    }
+
+    onChange && onChange([minValue, maxValue]);
+  };
+
+  const handleMaxThumb = (e: ChangeEvent<HTMLInputElement>) => {
+    if (includedValue && parseInt(e.target.value) < includedValue) {
+      return;
+    }
+
+    if (parseInt(e.target.value) < minValue) {
+      setMaxValue(minValue);
+    } else {
+      setMaxValue(parseInt(e.target.value));
+    }
+
+    onChange && onChange([minValue, maxValue]);
+  };
+
+  return (
+    <div className='mx-auto w-full px-4'>
+      <div className='relative'>
+        <input
+          type='range'
+          value={minValue}
+          min={min}
+          max={max}
+          step={step}
+          list='markers'
+          onChange={handleMinThumb}
+          className={`input-range ${minValue === max ? 'z-10' : 'z-[1px]'}`}
+        />
+        <input
+          type='range'
+          value={maxValue}
+          min={min}
+          max={max}
+          step={step}
+          list='markers'
+          style={{
+            background: `linear-gradient(
+            to right,
+            #f0f0f0 0%,
+            #f0f0f0 ${((minValue - min) / range) * 100}%,
+            #8b5cf6 ${((minValue - min) / range) * 100}%,
+            #8b5cf6 ${((maxValue - min) / range) * 100}%,
+            #f0f0f0 ${((maxValue - min) / range) * 100}%,
+            #f0f0f0 100%
+          )`,
+          }}
+          onChange={handleMaxThumb}
+          className={`input-range ${maxValue === min ? 'z-10' : 'z-[1px]'}`}
+        />
+        <datalist
+          id='markers'
+          className='flex h-fit w-full translate-y-4 justify-between text-primary'
+        >
+          {ticks.map(tick => (
+            <option value={tick}>{tick}</option>
+          ))}
+        </datalist>
+      </div>
+    </div>
+  );
+};
+
+export default Range;

--- a/src/components/Range/index.tsx
+++ b/src/components/Range/index.tsx
@@ -6,7 +6,7 @@ interface RangeProps {
   step: number;
   defaultValue: number[];
   includedValue?: number;
-  onChange: (value: number[]) => void;
+  onChange: (values: number[]) => void;
 }
 
 const Range = ({

--- a/src/components/Range/index.tsx
+++ b/src/components/Range/index.tsx
@@ -1,10 +1,12 @@
 import { ChangeEvent, useState } from 'react';
 
+import { cn } from '@/utils/cn';
+
 interface RangeProps {
   min: number;
   max: number;
   step: number;
-  defaultValue: number[];
+  value: number[];
   includedValue?: number;
   onChange: (values: number[]) => void;
 }
@@ -13,11 +15,11 @@ const Range = ({
   min,
   max,
   step,
-  defaultValue = [min, max],
+  value,
   includedValue,
   onChange,
 }: RangeProps) => {
-  const [from, to] = defaultValue;
+  const [from, to] = value;
 
   const [minValue, setMinValue] = useState(from);
   const [maxValue, setMaxValue] = useState(to);
@@ -30,31 +32,29 @@ const Range = ({
   );
 
   const handleMinThumb = (e: ChangeEvent<HTMLInputElement>) => {
-    if (includedValue && parseInt(e.target.value) > includedValue) {
+    const inputValue = parseInt(e.target.value);
+
+    if (includedValue !== undefined && inputValue > includedValue) {
       return;
     }
 
-    if (parseInt(e.target.value) > maxValue) {
-      setMinValue(maxValue);
-    } else {
-      setMinValue(parseInt(e.target.value));
-    }
+    const nextMinValue = Math.min(maxValue, inputValue);
+    setMinValue(nextMinValue);
 
-    onChange && onChange([minValue, maxValue]);
+    onChange([nextMinValue, maxValue]);
   };
 
   const handleMaxThumb = (e: ChangeEvent<HTMLInputElement>) => {
-    if (includedValue && parseInt(e.target.value) < includedValue) {
+    const inputValue = parseInt(e.target.value);
+
+    if (includedValue !== undefined && inputValue < includedValue) {
       return;
     }
 
-    if (parseInt(e.target.value) < minValue) {
-      setMaxValue(minValue);
-    } else {
-      setMaxValue(parseInt(e.target.value));
-    }
+    const nextMaxValue = Math.max(minValue, inputValue);
 
-    onChange && onChange([minValue, maxValue]);
+    setMaxValue(nextMaxValue);
+    onChange([minValue, nextMaxValue]);
   };
 
   return (
@@ -68,7 +68,12 @@ const Range = ({
           step={step}
           list='markers'
           onChange={handleMinThumb}
-          className={`input-range ${minValue === max ? 'z-10' : 'z-[1px]'}`}
+          className={cn(
+            'input-range',
+            minValue === max
+              ? '[&::-moz-range-thumb]:z-10 [&::-webkit-slider-thumb]:z-10'
+              : '[&::-moz-range-thumb]:z-[1] [&::-webkit-slider-thumb]:z-[1]',
+          )}
         />
         <input
           type='range'
@@ -89,14 +94,21 @@ const Range = ({
           )`,
           }}
           onChange={handleMaxThumb}
-          className={`input-range ${maxValue === min ? 'z-10' : 'z-[1px]'}`}
+          className={cn(
+            'input-range',
+            maxValue === min
+              ? '[&::-moz-range-thumb]:z-10 [&::-webkit-slider-thumb]:z-10'
+              : '[&::-moz-range-thumb]:z-[1] [&::-webkit-slider-thumb]:z-[1]',
+          )}
         />
         <datalist
           id='markers'
-          className='flex h-fit w-full translate-y-4 justify-between text-primary'
+          className='flex h-fit w-full translate-y-4 justify-between text-gray-accent2'
         >
           {ticks.map(tick => (
-            <option value={tick}>{tick}</option>
+            <option key={tick} value={tick}>
+              {tick}
+            </option>
           ))}
         </datalist>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -32,44 +32,15 @@
 
 @layer components {
   .input-range::-webkit-slider-thumb {
-    height: 12px;
-    width: 12px;
-    border-radius: 50%;
-    background-color: var(--primary);
-    position: relative;
-    transform: translate(0, -6.75px);
-    cursor: pointer;
-    appearance: none;
-    pointer-events: all;
-    z-index: 1;
+    @apply pointer-events-auto relative z-[1] h-3 w-3 translate-y-[-6.75px] cursor-pointer appearance-none rounded-md bg-[var(--primary)];
   }
 
   .input-range::-moz-range-thumb {
-    height: 12px;
-    width: 12px;
-    border-radius: 50%;
-    background-color: var(--primary);
-    position: relative;
-    transform: translate(0, -6.75px);
-    cursor: pointer;
-    appearance: none;
-    pointer-events: all;
-    z-index: 1;
-  }
-
-  .input-range::-webkit-slider-thumb:hover {
-    background-color: var(--primary-darken);
+    @apply pointer-events-auto relative z-[1] h-3 w-3 translate-y-[-6.75px] cursor-pointer appearance-none rounded-md bg-[var(--primary)];
   }
 
   .input-range {
-    position: absolute;
-    appearance: none;
-    height: 8px;
-    width: 100%;
-    border-radius: 8px;
-    outline: none;
-    background-color: var(--accent-7);
-    pointer-events: none;
+    @apply pointer-events-none absolute	h-2 w-full appearance-none rounded-lg bg-[var(--accent-7)] outline-none [&::-webkit-slider-thumb:hover]:bg-[var(--primary-darken)];
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,49 @@
   }
 }
 
+@layer components {
+  .input-range::-webkit-slider-thumb {
+    height: 12px;
+    width: 12px;
+    border-radius: 50%;
+    background-color: var(--primary);
+    position: relative;
+    transform: translate(0, -6.75px);
+    cursor: pointer;
+    appearance: none;
+    pointer-events: all;
+    z-index: 1;
+  }
+
+  .input-range::-moz-range-thumb {
+    height: 12px;
+    width: 12px;
+    border-radius: 50%;
+    background-color: var(--primary);
+    position: relative;
+    transform: translate(0, -6.75px);
+    cursor: pointer;
+    appearance: none;
+    pointer-events: all;
+    z-index: 1;
+  }
+
+  .input-range::-webkit-slider-thumb:hover {
+    background-color: var(--primary-darken);
+  }
+
+  .input-range {
+    position: absolute;
+    appearance: none;
+    height: 8px;
+    width: 100%;
+    border-radius: 8px;
+    outline: none;
+    background-color: var(--accent-7);
+    pointer-events: none;
+  }
+}
+
 @layer utilities {
   @keyframes RippleEffect {
     0% {

--- a/src/index.css
+++ b/src/index.css
@@ -40,7 +40,7 @@
   }
 
   .input-range {
-    @apply pointer-events-none absolute	h-2 w-full appearance-none rounded-lg bg-[var(--accent-7)] outline-none [&::-webkit-slider-thumb:hover]:bg-[var(--primary-darken)];
+    @apply pointer-events-none absolute	h-2 w-full appearance-none rounded-lg bg-[var(--accent-7)] outline-none [&::-moz-range-thumb:hover]:bg-[var(--primary-darken)] [&::-webkit-slider-thumb:hover]:bg-[var(--primary-darken)];
   }
 }
 

--- a/src/stories/components/Range.stories.tsx
+++ b/src/stories/components/Range.stories.tsx
@@ -24,7 +24,7 @@ export const Headcount = (args: Story) => {
       max={8}
       step={1}
       value={headcountValues}
-      onChange={(values: number[]) => setHeadcountValues([...values])}
+      onChange={setHeadcountValues}
     />
   );
 };
@@ -40,7 +40,7 @@ export const Age = (args: Story) => {
       step={5}
       value={ageValues}
       includedValue={26}
-      onChange={(values: number[]) => setAgeValues(values)}
+      onChange={setAgeValues}
     />
   );
 };

--- a/src/stories/components/Range.stories.tsx
+++ b/src/stories/components/Range.stories.tsx
@@ -15,7 +15,7 @@ export default meta;
 type Story = StoryObj<typeof Range>;
 
 export const Headcount = (args: Story) => {
-  const [headcountValue, setHeadcountValue] = useState<number[]>([3, 5]);
+  const [headcountValues, setHeadcountValues] = useState<number[]>([3, 5]);
 
   return (
     <Range
@@ -23,14 +23,14 @@ export const Headcount = (args: Story) => {
       min={1}
       max={8}
       step={1}
-      defaultValue={headcountValue}
-      onChange={(value: number[]) => setHeadcountValue(value)}
+      defaultValue={headcountValues}
+      onChange={(value: number[]) => setHeadcountValues(value)}
     />
   );
 };
 
 export const Age = (args: Story) => {
-  const [ageValue, setAgeValue] = useState<number[]>([20, 30]);
+  const [ageValues, setAgeValues] = useState<number[]>([20, 30]);
 
   return (
     <Range
@@ -38,9 +38,9 @@ export const Age = (args: Story) => {
       min={10}
       max={40}
       step={5}
-      defaultValue={ageValue}
+      defaultValue={ageValues}
       includedValue={26}
-      onChange={(value: number[]) => setAgeValue(value)}
+      onChange={(value: number[]) => setAgeValues(value)}
     />
   );
 };

--- a/src/stories/components/Range.stories.tsx
+++ b/src/stories/components/Range.stories.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Range from '@/components/Range';
+
+const meta: Meta<typeof Range> = {
+  title: 'components/Range',
+  tags: ['autodocs'],
+  component: Range,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Range>;
+
+export const Headcount = (args: Story) => {
+  const [headcountValue, setHeadcountValue] = useState<number[]>([3, 5]);
+
+  return (
+    <Range
+      {...args}
+      min={1}
+      max={8}
+      step={1}
+      defaultValue={headcountValue}
+      onChange={(value: number[]) => setHeadcountValue(value)}
+    />
+  );
+};
+
+export const Age = (args: Story) => {
+  const [ageValue, setAgeValue] = useState<number[]>([20, 30]);
+
+  return (
+    <Range
+      {...args}
+      min={10}
+      max={40}
+      step={5}
+      defaultValue={ageValue}
+      includedValue={26}
+      onChange={(value: number[]) => setAgeValue(value)}
+    />
+  );
+};

--- a/src/stories/components/Range.stories.tsx
+++ b/src/stories/components/Range.stories.tsx
@@ -15,7 +15,7 @@ export default meta;
 type Story = StoryObj<typeof Range>;
 
 export const Headcount = (args: Story) => {
-  const [headcountValues, setHeadcountValues] = useState<number[]>([3, 5]);
+  const [headcountValues, setHeadcountValues] = useState([3, 5]);
 
   return (
     <Range
@@ -23,8 +23,8 @@ export const Headcount = (args: Story) => {
       min={1}
       max={8}
       step={1}
-      defaultValue={headcountValues}
-      onChange={(value: number[]) => setHeadcountValues(value)}
+      value={headcountValues}
+      onChange={(values: number[]) => setHeadcountValues([...values])}
     />
   );
 };
@@ -38,7 +38,7 @@ export const Age = (args: Story) => {
       min={10}
       max={40}
       step={5}
-      defaultValue={ageValues}
+      value={ageValues}
       includedValue={26}
       onChange={(values: number[]) => setAgeValues(values)}
     />

--- a/src/stories/components/Range.stories.tsx
+++ b/src/stories/components/Range.stories.tsx
@@ -40,7 +40,7 @@ export const Age = (args: Story) => {
       step={5}
       defaultValue={ageValues}
       includedValue={26}
-      onChange={(value: number[]) => setAgeValues(value)}
+      onChange={(values: number[]) => setAgeValues(values)}
     />
   );
 };


### PR DESCRIPTION
## 💬 Issue Number

> closes #40 

## 🤷‍♂️ Description
- 모임 생성 시 모집 인원, 모집 연령대를 설정할 수 있는 양방향 Range 컴포넌트입니다.
- 모집 연령대 설정 시 모임 생성자 연령이 반드시 포함되도록 구현했습니다.

## 📷 Screenshots
<img src="https://github.com/BoardSignal/Team-CivilWar-BoardSignal-FE/assets/42732729/26f1f7d1-cc7b-4467-8349-304568ee3928" width="50%"><img src="https://github.com/BoardSignal/Team-CivilWar-BoardSignal-FE/assets/42732729/a6473b69-588e-4d73-a57b-a87243ec6705" width="50%">

## 👻 Good Function
### 사용법
```javascript
const [ageValues, setAgeValues] = useState<number[]>([20, 30]);

return (
  <Range
    {...args}
    min={10}
    max={40}
    step={5}
    defaultValue={ageValues}
    includedValue={26} // 모임 생성자 연령
    onChange={(values: number[]) => setAgeValues(values)}
  />
);
```

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 📒 Remarks
컴포넌트를 구현할 때 아래 두 가지 방안을 생각했습니다.
- 사용처에서 `min`, `max`, `step`을 props로 전달 (현재 구현된 방식)
- 인원/연령대를 `variants`로 설정하고 컴포넌트 내에서 `min`, `max`, `step`을 지정하여 사용 시 전달할 props를 줄이기

고민 하다가 모임 생성 페이지에 종속된 컴포넌트가 아닌 공통 컴포넌트기 때문에 지금처럼 구현했습니다. 관련해서 의견 있다면 나눠주세요!
