### PR TITLE
[#41] Feat: 공통컴포넌트 - Select

### DIFF
--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -15,6 +15,7 @@ interface SelectProps
  * Select 컴포넌트는 필수로 값을 전달해야 하며,
  * option을 선택한 뒤에는 취소할 수 없습니다.
  *
+ * value 초깃값은 빈 string('')만 가능합니다.
  */
 
 const Select = ({ options, placeholder, onChange, ...props }: SelectProps) => {

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,0 +1,51 @@
+import { ChangeEvent, ComponentPropsWithoutRef, useState } from 'react';
+
+import { cn } from '@/utils/cn';
+
+import Icon from '../Icon';
+
+interface SelectProps
+  extends Omit<ComponentPropsWithoutRef<'select'>, 'onChange'> {
+  options: string[];
+  placeholder: string;
+  onChange: (value: string) => void;
+}
+
+const Select = ({ options, placeholder, onChange, ...props }: SelectProps) => {
+  const [isPlaceholder, setIsPlaceholder] = useState(true);
+
+  const handleChangeValue = (e: ChangeEvent<HTMLSelectElement>) => {
+    onChange(e.target.value);
+
+    if (!isPlaceholder) return;
+
+    setIsPlaceholder(false);
+  };
+
+  return (
+    <div className='relative w-full rounded-lg border border-gray-accent7'>
+      <select
+        className={cn(
+          '[::-ms-expand]:hidden relative z-10 w-full cursor-pointer appearance-none rounded-lg border-0 bg-transparent p-4 outline-gray-accent2',
+          isPlaceholder ? 'text-gray-accent4' : 'text-gray-accent1',
+        )}
+        onChange={handleChangeValue}
+        {...props}
+      >
+        <option value={placeholder} disabled hidden>
+          {placeholder}
+        </option>
+        {options.map(option => (
+          <option key={option} value={option} className='text-gray-accent1'>
+            {option}
+          </option>
+        ))}
+      </select>
+      <span className='absolute right-0 top-0 flex h-full items-center justify-center pr-4 text-gray-accent4'>
+        <Icon id='arrow-bottom-line' size={24} />
+      </span>
+    </div>
+  );
+};
+
+export default Select;

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -11,23 +11,29 @@ interface SelectProps
   onChange: (value: string) => void;
 }
 
+/**
+ * Select 컴포넌트는 필수로 값을 전달해야 하며,
+ * option을 선택한 뒤에는 취소할 수 없습니다.
+ *
+ */
+
 const Select = ({ options, placeholder, onChange, ...props }: SelectProps) => {
-  const [isPlaceholder, setIsPlaceholder] = useState(true);
+  const [isShowingPlaceholder, setIsShowingPlaceholder] = useState(true);
 
   const handleChangeValue = (e: ChangeEvent<HTMLSelectElement>) => {
     onChange(e.target.value);
 
-    if (!isPlaceholder) return;
-
-    setIsPlaceholder(false);
+    if (isShowingPlaceholder) {
+      setIsShowingPlaceholder(false);
+    }
   };
 
   return (
-    <div className='relative w-full rounded-lg border border-gray-accent7'>
+    <div className='relative'>
       <select
         className={cn(
-          '[::-ms-expand]:hidden relative z-10 w-full cursor-pointer appearance-none rounded-lg border-0 bg-transparent p-4 outline-gray-accent2',
-          isPlaceholder ? 'text-gray-accent4' : 'text-gray-accent1',
+          'relative z-10 w-full cursor-pointer appearance-none rounded-lg border bg-transparent p-4 outline-gray-accent2',
+          isShowingPlaceholder ? 'text-gray-accent4' : 'text-gray-accent1',
         )}
         onChange={handleChangeValue}
         {...props}
@@ -41,8 +47,8 @@ const Select = ({ options, placeholder, onChange, ...props }: SelectProps) => {
           </option>
         ))}
       </select>
-      <span className='absolute right-0 top-0 flex h-full items-center justify-center pr-4 text-gray-accent4'>
-        <Icon id='arrow-bottom-line' size={24} />
+      <span className='absolute right-4 top-4'>
+        <Icon id='arrow-bottom-line' size={24} className='text-gray-accent4' />
       </span>
     </div>
   );

--- a/src/stories/components/Select.stories.tsx
+++ b/src/stories/components/Select.stories.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Select from '@/components/Select';
+
+const meta: Meta<typeof Select> = {
+  title: 'components/Select',
+  tags: ['autodocs'],
+  component: Select,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Select>;
+
+export const DefaultTemplate = (args: Story) => {
+  const OPTIONS = ['평일 오전', '평일 오후', '주말 오전', '주말 오후'];
+  const PLACEHOLDER_TEXT = '시간대 선택';
+
+  const [selectValue, setSelectValue] = useState(PLACEHOLDER_TEXT);
+
+  return (
+    <Select
+      {...args}
+      options={OPTIONS}
+      placeholder={PLACEHOLDER_TEXT}
+      value={selectValue}
+      onChange={setSelectValue}
+    />
+  );
+};


### PR DESCRIPTION
## 💬 Issue Number

> closes #41 

## 🤷‍♂️ Description
- 단일 옵션 선택이 가능한 `Select` 컴포넌트입니다.

## 📷 Screenshots
<img src="https://github.com/BoardSignal/Team-CivilWar-BoardSignal-FE/assets/42732729/a92153b7-7765-491a-9c66-0a9ee47efadc" width="50%">


## 👻 Good Function
### 사용법
```javascript
<Select
  options={OPTIONS} // 옵션에 들어갈 text 배열
  placeholder={PLACEHOLDER_TEXT} // 옵션이 선택되지 않았을 때 표시할 text
  value={selectValue}
  onChange={setSelectValue}
/>
```

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 📒 Remarks
- 기본 `select`를 사용하니 스타일을 적용하는데 제한적인 부분이 많네요😂