### PR TITLE
[#63] Feat: 모임 상세 페이지 - 모임 소개

### DIFF
--- a/src/pages/GatheringDetail/GatheringIntroduce/components/GatheringDescription/index.tsx
+++ b/src/pages/GatheringDetail/GatheringIntroduce/components/GatheringDescription/index.tsx
@@ -8,7 +8,7 @@ const GatheringDescription = ({
   description,
 }: GatheringDescriptionProps) => {
   return (
-    <div className='flex w-full flex-col p-5'>
+    <div className='flex w-full flex-col'>
       <span className='text-xl font-bold'>{title}</span>
       <span className='mb-4 mt-1 text-[10px] text-gray-accent3 underline'>
         3시간 전에 작성됨 (10분 전에 수정됨)

--- a/src/pages/GatheringDetail/GatheringIntroduce/components/GatheringDescription/index.tsx
+++ b/src/pages/GatheringDetail/GatheringIntroduce/components/GatheringDescription/index.tsx
@@ -1,0 +1,21 @@
+interface GatheringDescriptionProps {
+  title: string;
+  description: string;
+}
+
+const GatheringDescription = ({
+  title,
+  description,
+}: GatheringDescriptionProps) => {
+  return (
+    <div className='flex w-full flex-col p-5'>
+      <span className='text-xl font-bold'>{title}</span>
+      <span className='mb-4 mt-1 text-[10px] text-gray-accent3 underline'>
+        3시간 전에 작성됨 (10분 전에 수정됨)
+      </span>
+      <p className='text-sm text-gray-accent2'>{description}</p>
+    </div>
+  );
+};
+
+export default GatheringDescription;

--- a/src/pages/GatheringDetail/GatheringIntroduce/components/GatheringGuide/index.tsx
+++ b/src/pages/GatheringDetail/GatheringIntroduce/components/GatheringGuide/index.tsx
@@ -7,7 +7,7 @@ interface GatheringGuide {
   minParticipants: number;
   maxParticipants: number;
   categories: string[];
-  isAllowedAppositeGender: boolean;
+  isAllowedAppositeGender: string;
   minAge: number;
   maxAge: number;
 }

--- a/src/pages/GatheringDetail/GatheringIntroduce/components/GatheringGuide/index.tsx
+++ b/src/pages/GatheringDetail/GatheringIntroduce/components/GatheringGuide/index.tsx
@@ -1,0 +1,66 @@
+import Icon from '@/components/Icon';
+import { IconName } from '@/components/Icon/type';
+
+interface GatheringGuide {
+  startTime: string;
+  place: string;
+  minParticipants: number;
+  maxParticipants: number;
+  categories: string[];
+  isAllowedAppositeGender: boolean;
+  minAge: number;
+  maxAge: number;
+}
+
+interface GatheringGuideProps {
+  gatheringGuide: GatheringGuide;
+}
+
+interface GuideItemProps {
+  iconId: IconName;
+  label: string;
+  content: string;
+}
+
+const GuideItem = ({ iconId, label, content }: GuideItemProps) => (
+  <div className='mt-3 flex'>
+    <Icon id={iconId} size={13}></Icon>
+    <span className='ml-1 w-20 text-[10px] font-bold'>{label}</span>
+    <span className='text-[12px]'>{content}</span>
+  </div>
+);
+
+const GatheringGuide = ({ gatheringGuide }: GatheringGuideProps) => {
+  const {
+    startTime,
+    place,
+    minParticipants,
+    maxParticipants,
+    categories,
+    isAllowedAppositeGender,
+    maxAge,
+    minAge,
+  } = gatheringGuide;
+
+  const ageGroup = `${minAge} ~ ${maxAge}세`;
+  const participantsGroup = `${minParticipants} ~ ${maxParticipants}명`;
+  const gender = isAllowedAppositeGender ? '혼성' : '동성';
+
+  return (
+    <div className='h-[240px] w-full rounded-lg bg-gray-accent7 p-5'>
+      <span className='font-bold'>모임 조건 안내</span>
+      <GuideItem iconId='time-fill' label='시간대' content={startTime} />
+      <GuideItem iconId='map-pin-fill' label='장소' content={place} />
+      <GuideItem iconId='team-fill' label='인원' content={participantsGroup} />
+      <GuideItem iconId='user-fill' label='나이대' content={ageGroup} />
+      <GuideItem
+        iconId='gamepad-fill'
+        label='게임 카테고리'
+        content={categories.join(' · ')}
+      />
+      <GuideItem iconId='men-fill' label='성별' content={gender} />
+    </div>
+  );
+};
+
+export default GatheringGuide;

--- a/src/pages/GatheringDetail/GatheringIntroduce/components/GatheringGuide/index.tsx
+++ b/src/pages/GatheringDetail/GatheringIntroduce/components/GatheringGuide/index.tsx
@@ -2,8 +2,10 @@ import Icon from '@/components/Icon';
 import { IconName } from '@/components/Icon/type';
 
 interface GatheringGuide {
-  startTime: string;
-  place: string;
+  time: string;
+  startTime: string | null;
+  subwayStation: string;
+  place: string | null;
   minParticipants: number;
   maxParticipants: number;
   categories: string[];
@@ -34,7 +36,9 @@ const GuideItem = ({ iconId, label, content }: GuideItemProps) => (
 
 const GatheringGuide = ({ gatheringGuide }: GatheringGuideProps) => {
   const {
+    time,
     startTime,
+    subwayStation,
     place,
     minParticipants,
     maxParticipants,
@@ -50,8 +54,16 @@ const GatheringGuide = ({ gatheringGuide }: GatheringGuideProps) => {
   return (
     <div className='flex w-full flex-col gap-2 rounded-lg bg-gray-accent7 p-4'>
       <span className='font-bold'>모임 조건 안내</span>
-      <GuideItem iconId='time-fill' label='시간대' content={startTime} />
-      <GuideItem iconId='map-pin-fill' label='장소' content={place} />
+      <GuideItem
+        iconId='time-fill'
+        label='시간대'
+        content={startTime ? startTime : time}
+      />
+      <GuideItem
+        iconId='map-pin-fill'
+        label='장소'
+        content={place ? `${place} (${subwayStation})` : subwayStation}
+      />
       <GuideItem iconId='team-fill' label='인원' content={participantsGroup} />
       <GuideItem iconId='user-fill' label='나이대' content={ageGroup} />
       <GuideItem

--- a/src/pages/GatheringDetail/GatheringIntroduce/components/GatheringGuide/index.tsx
+++ b/src/pages/GatheringDetail/GatheringIntroduce/components/GatheringGuide/index.tsx
@@ -26,7 +26,7 @@ interface GuideItemProps {
 
 const GuideItem = ({ iconId, label, content }: GuideItemProps) => (
   <div className='flex gap-2'>
-    <div className='flex w-[70px] gap-0.5'>
+    <div className='flex w-[75px] gap-0.5'>
       <Icon id={iconId} size={12}></Icon>
       <span className='ml-1 w-20 text-[10px] font-bold'>{label}</span>
     </div>

--- a/src/pages/GatheringDetail/GatheringIntroduce/components/GatheringGuide/index.tsx
+++ b/src/pages/GatheringDetail/GatheringIntroduce/components/GatheringGuide/index.tsx
@@ -7,7 +7,7 @@ interface GatheringGuide {
   minParticipants: number;
   maxParticipants: number;
   categories: string[];
-  isAllowedAppositeGender: string;
+  allowedGender: string;
   minAge: number;
   maxAge: number;
 }
@@ -23,10 +23,12 @@ interface GuideItemProps {
 }
 
 const GuideItem = ({ iconId, label, content }: GuideItemProps) => (
-  <div className='mt-3 flex'>
-    <Icon id={iconId} size={13}></Icon>
-    <span className='ml-1 w-20 text-[10px] font-bold'>{label}</span>
-    <span className='text-[12px]'>{content}</span>
+  <div className='flex gap-2'>
+    <div className='flex w-[70px] gap-0.5'>
+      <Icon id={iconId} size={12}></Icon>
+      <span className='ml-1 w-20 text-[10px] font-bold'>{label}</span>
+    </div>
+    <span className='text-xs'>{content}</span>
   </div>
 );
 
@@ -37,17 +39,16 @@ const GatheringGuide = ({ gatheringGuide }: GatheringGuideProps) => {
     minParticipants,
     maxParticipants,
     categories,
-    isAllowedAppositeGender,
+    allowedGender,
     maxAge,
     minAge,
   } = gatheringGuide;
 
   const ageGroup = `${minAge} ~ ${maxAge}세`;
   const participantsGroup = `${minParticipants} ~ ${maxParticipants}명`;
-  const gender = isAllowedAppositeGender ? '혼성' : '동성';
 
   return (
-    <div className='h-[240px] w-full rounded-lg bg-gray-accent7 p-5'>
+    <div className='flex w-full flex-col gap-2 rounded-lg bg-gray-accent7 p-4'>
       <span className='font-bold'>모임 조건 안내</span>
       <GuideItem iconId='time-fill' label='시간대' content={startTime} />
       <GuideItem iconId='map-pin-fill' label='장소' content={place} />
@@ -58,7 +59,7 @@ const GatheringGuide = ({ gatheringGuide }: GatheringGuideProps) => {
         label='게임 카테고리'
         content={categories.join(' · ')}
       />
-      <GuideItem iconId='men-fill' label='성별' content={gender} />
+      <GuideItem iconId='men-fill' label='성별' content={allowedGender} />
     </div>
   );
 };

--- a/src/pages/GatheringDetail/GatheringIntroduce/components/TabMenu/index.tsx
+++ b/src/pages/GatheringDetail/GatheringIntroduce/components/TabMenu/index.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+interface TabMenuProps {
+  tabs: string[];
+  onSelectTab: (index: number) => void;
+}
+
+const TabMenu = ({ tabs, onSelectTab }: TabMenuProps) => {
+  const [activeTab, setActiveTab] = useState(0);
+
+  const handleTabClick = (index: number) => {
+    setActiveTab(index);
+    onSelectTab(index);
+  };
+
+  return (
+    <div className='flex'>
+      {tabs.map((tab, index) => (
+        <div
+          key={index}
+          className={` h-[40px] w-full cursor-pointer border-t pt-2 text-center ${activeTab === index ? 'border-b-[5px] border-b-primary text-primary' : ' text-gray-accent4'}`}
+          onClick={() => handleTabClick(index)}
+        >
+          {tab}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default TabMenu;

--- a/src/pages/GatheringDetail/GatheringIntroduce/components/TabMenu/index.tsx
+++ b/src/pages/GatheringDetail/GatheringIntroduce/components/TabMenu/index.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+import { cn } from '@/utils/cn';
+
 interface TabMenuProps {
   tabs: string[];
   onSelectTab: (index: number) => void;
@@ -18,7 +20,14 @@ const TabMenu = ({ tabs, onSelectTab }: TabMenuProps) => {
       {tabs.map((tab, index) => (
         <div
           key={index}
-          className={`h-[40px] w-full cursor-pointer border-t pt-2 text-center ${activeTab === index ? 'border-b-[5px] border-b-primary text-primary' : ' text-gray-accent4'}`}
+          className={cn(
+            'h-[40px] w-full cursor-pointer border-t pt-2 text-center',
+            {
+              'border-b-[5px] border-b-primary text-primary':
+                activeTab === index,
+              'text-gray-accent4': activeTab !== index,
+            },
+          )}
           onClick={() => handleTabClick(index)}
         >
           {tab}

--- a/src/pages/GatheringDetail/GatheringIntroduce/components/TabMenu/index.tsx
+++ b/src/pages/GatheringDetail/GatheringIntroduce/components/TabMenu/index.tsx
@@ -18,7 +18,7 @@ const TabMenu = ({ tabs, onSelectTab }: TabMenuProps) => {
       {tabs.map((tab, index) => (
         <div
           key={index}
-          className={` h-[40px] w-full cursor-pointer border-t pt-2 text-center ${activeTab === index ? 'border-b-[5px] border-b-primary text-primary' : ' text-gray-accent4'}`}
+          className={`h-[40px] w-full cursor-pointer border-t pt-2 text-center ${activeTab === index ? 'border-b-[5px] border-b-primary text-primary' : ' text-gray-accent4'}`}
           onClick={() => handleTabClick(index)}
         >
           {tab}

--- a/src/pages/GatheringDetail/GatheringIntroduce/index.tsx
+++ b/src/pages/GatheringDetail/GatheringIntroduce/index.tsx
@@ -14,8 +14,10 @@ const DEFAULT_IMAGE_URL = 'https://picsum.photos/200/200';
 
 const GATHERING_INTRO_DUMMY_DATA = {
   gatheringGuide: {
-    startTime: '토요일 오후',
+    time: '토요일 오후',
+    startTime: '',
     place: '사당역 근처 레드버튼',
+    subwayStation: '사당역',
     minParticipants: 1,
     maxParticipants: 8,
     categories: ['전략게임', '워게임'],
@@ -54,7 +56,7 @@ const GatheringIntroduce = ({ imageUrl }: GatheringIntroduceProps) => {
           onSelectTab={handleTabSelect}
         />
         {activeTab === 0 && (
-          <div>
+          <div className='overflow-y-auto'>
             {imageUrl && (
               <img
                 src={imageUrl}

--- a/src/pages/GatheringDetail/GatheringIntroduce/index.tsx
+++ b/src/pages/GatheringDetail/GatheringIntroduce/index.tsx
@@ -7,7 +7,7 @@ import GatheringGuide from './components/GatheringGuide';
 import TabMenu from './components/TabMenu';
 
 interface GatheringIntroduceProps {
-  imageUrl?: string;
+  imageUrl?: string | null;
 }
 
 const DEFAULT_IMAGE_URL = 'https://picsum.photos/200/200';
@@ -19,13 +19,14 @@ const GATHERING_INTRO_DUMMY_DATA = {
     minParticipants: 1,
     maxParticipants: 8,
     categories: ['전략게임', '워게임'],
-    isAllowedAppositeGender: '혼성',
+    allowedGender: '남성',
     maxAge: 21,
     minAge: 28,
   },
   title: '정령섬 심화 격주로 하실 1~2분',
   description: '예전보다 소개팅도 줄어들고~',
   isLeader: false,
+  imageUrl: DEFAULT_IMAGE_URL,
 };
 
 const GatheringIntroduce = ({ imageUrl }: GatheringIntroduceProps) => {
@@ -56,13 +57,14 @@ const GatheringIntroduce = ({ imageUrl }: GatheringIntroduceProps) => {
           <div>
             {imageUrl && (
               <img
-                src={imageUrl || DEFAULT_IMAGE_URL}
+                src={imageUrl}
                 alt='모임 이미지'
                 className='h-[350px] w-full object-cover'
               />
             )}
-            <GatheringDescription title={title} description={description} />
-            <div className='m-5 '>
+
+            <div className='flex flex-col gap-4 px-4 py-6'>
+              <GatheringDescription title={title} description={description} />
               <GatheringGuide gatheringGuide={gatheringGuide} />
             </div>
           </div>

--- a/src/pages/GatheringDetail/GatheringIntroduce/index.tsx
+++ b/src/pages/GatheringDetail/GatheringIntroduce/index.tsx
@@ -1,7 +1,10 @@
+import { useState } from 'react';
+
 import TabBar from '@/components/TabBar';
 
 import GatheringDescription from './components/GatheringDescription';
 import GatheringGuide from './components/GatheringGuide';
+import TabMenu from './components/TabMenu';
 
 interface GatheringIntroduceProps {
   imageUrl?: string;
@@ -27,6 +30,11 @@ const GATHERING_INTRO_DUMMY_DATA = {
 
 const GatheringIntroduce = ({ imageUrl }: GatheringIntroduceProps) => {
   const { title, description, gatheringGuide } = GATHERING_INTRO_DUMMY_DATA;
+  const [activeTab, setActiveTab] = useState(0);
+
+  const handleTabSelect = (index: number) => {
+    setActiveTab(index);
+  };
 
   return (
     <div className='flex h-full flex-col'>
@@ -40,17 +48,26 @@ const GatheringIntroduce = ({ imageUrl }: GatheringIntroduceProps) => {
       </TabBar.Container>
 
       <div>
-        {imageUrl && (
-          <img
-            src={imageUrl || DEFAULT_IMAGE_URL}
-            alt='모임 이미지'
-            className='h-[350px] w-full object-cover'
-          />
+        <TabMenu
+          tabs={['모임 소개', '참가자 ()']}
+          onSelectTab={handleTabSelect}
+        />
+        {activeTab === 0 && (
+          <div>
+            {imageUrl && (
+              <img
+                src={imageUrl || DEFAULT_IMAGE_URL}
+                alt='모임 이미지'
+                className='h-[350px] w-full object-cover'
+              />
+            )}
+            <GatheringDescription title={title} description={description} />
+            <div className='m-5 '>
+              <GatheringGuide gatheringGuide={gatheringGuide} />
+            </div>
+          </div>
         )}
-        <GatheringDescription title={title} description={description} />
-        <div className='p-5'>
-          <GatheringGuide gatheringGuide={gatheringGuide} />
-        </div>
+        {activeTab === 1 && <div>{/* 참가자 프로필*/}</div>}
       </div>
     </div>
   );

--- a/src/pages/GatheringDetail/GatheringIntroduce/index.tsx
+++ b/src/pages/GatheringDetail/GatheringIntroduce/index.tsx
@@ -1,0 +1,59 @@
+import TabBar from '@/components/TabBar';
+
+import GatheringDescription from './components/GatheringDescription';
+import GatheringGuide from './components/GatheringGuide';
+
+interface GatheringIntroduceProps {
+  imageUrl?: string;
+}
+
+const DEFAULT_IMAGE_URL = 'https://picsum.photos/200/200';
+
+const GATHERING_INTRO_DUMMY_DATA = {
+  gatheringGuide: {
+    startTime: '토요일 오후',
+    place: '사당역 근처 레드버튼',
+    minParticipants: 1,
+    maxParticipants: 8,
+    categories: ['전략게임', '워게임'],
+    isAllowedAppositeGender: '혼성',
+    maxAge: 21,
+    minAge: 28,
+  },
+  title: '정령섬 심화 격주로 하실 1~2분',
+  description: '예전보다 소개팅도 줄어들고~',
+  isLeader: false,
+};
+
+const GatheringIntroduce = ({ imageUrl }: GatheringIntroduceProps) => {
+  const { title, description, gatheringGuide } = GATHERING_INTRO_DUMMY_DATA;
+
+  return (
+    <div className='flex h-full flex-col'>
+      <TabBar.Container>
+        <TabBar.Left>
+          <TabBar.GoBackButton />
+        </TabBar.Left>
+        <TabBar.Right>
+          <TabBar.ShareButton />
+        </TabBar.Right>
+      </TabBar.Container>
+
+      <div>
+        {imageUrl && (
+          <img
+            src={imageUrl || DEFAULT_IMAGE_URL}
+            alt='모임 이미지'
+            className='h-[350px] w-full object-cover'
+          />
+        )}
+        <GatheringDescription title={title} description={description} />
+        <div className='p-5'>
+          <GatheringGuide gatheringGuide={gatheringGuide} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GatheringIntroduce;

--- a/src/pages/GatheringDetail/GatheringIntroduce/index.tsx
+++ b/src/pages/GatheringDetail/GatheringIntroduce/index.tsx
@@ -26,7 +26,8 @@ const GATHERING_INTRO_DUMMY_DATA = {
     minAge: 28,
   },
   title: '정령섬 심화 격주로 하실 1~2분',
-  description: '예전보다 소개팅도 줄어들고~',
+  description:
+    '두 명이서 하고 있습니다. 3~4인이 더 재밌어요. 확장 텍스트가 영문이라 읽을 수 있으시면 편해요.두 명이서 하고 있습니다. 3~4인이 더 재밌어요. 확장 텍스트가 영문이라 읽을 수 있으시면 편해요.두 명이서 하고 있습니다. 3~4인이 더 재밌어요. 확장 텍스트가 영문이라 읽을 수 있으시면 편해요.두 명이서 하고 있습니다. 3~4인이 더 재밌어요. 확장 텍스트가 영문이라 읽을 수 있으시면 편해요.두 명이서 하고 있습니다. 3~4인이 더 재밌어요. 확장 텍스트가 영문이라 읽을 수 있으시면 편해요.',
   isLeader: false,
   imageUrl: DEFAULT_IMAGE_URL,
 };
@@ -50,13 +51,13 @@ const GatheringIntroduce = ({ imageUrl }: GatheringIntroduceProps) => {
         </TabBar.Right>
       </TabBar.Container>
 
-      <div>
+      <div className='flex grow flex-col overflow-y-hidden'>
         <TabMenu
           tabs={['모임 소개', '참가자 ()']}
           onSelectTab={handleTabSelect}
         />
         {activeTab === 0 && (
-          <div className='overflow-y-auto'>
+          <div className='grow overflow-y-auto'>
             {imageUrl && (
               <img
                 src={imageUrl}

--- a/src/stories/pages/GatheringDetail/GatheringDescription.stories.tsx
+++ b/src/stories/pages/GatheringDetail/GatheringDescription.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import GatheringDescription from '@/pages/GatheringDetail/GatheringIntroduce/components/GatheringDescription/index';
+
+const meta: Meta<typeof GatheringDescription> = {
+  title: 'Pages/GatheringDetail/GatheringDescription',
+  tags: ['autodocs'],
+  component: GatheringDescription,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof GatheringDescription>;
+
+export const Default: Story = {
+  args: {
+    title: '정령섬 심화 격주로 하실 1~2분',
+    description:
+      '두 명이서 하고 있습니다. 3~4인이 더 재밌어요. 확장 텍스트가 영문이라 읽을 수 있으시면 편해요.',
+  },
+};

--- a/src/stories/pages/GatheringDetail/GatheringGuide.stories.tsx
+++ b/src/stories/pages/GatheringDetail/GatheringGuide.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import GatheringGuide from '@/pages/GatheringDetail/GatheringIntroduce/components/GatheringGuide/index';
+
+const meta: Meta<typeof GatheringGuide> = {
+  title: 'Pages/GatheringDetail/GatheringGuide',
+  tags: ['autodocs'],
+  component: GatheringGuide,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof GatheringGuide>;
+
+export const Default: Story = {
+  args: {
+    gatheringGuide: {
+      startTime: '토요일 오후',
+      place: '사당역 근처 레드버튼',
+      minParticipants: 2,
+      maxParticipants: 4,
+      categories: ['전략게임', '워게임'],
+      isAllowedAppositeGender: false,
+      minAge: 21,
+      maxAge: 28,
+    },
+  },
+};

--- a/src/stories/pages/GatheringDetail/GatheringGuide.stories.tsx
+++ b/src/stories/pages/GatheringDetail/GatheringGuide.stories.tsx
@@ -20,7 +20,7 @@ export const Default: Story = {
       minParticipants: 2,
       maxParticipants: 4,
       categories: ['전략게임', '워게임'],
-      isAllowedAppositeGender: false,
+      isAllowedAppositeGender: '혼성',
       minAge: 21,
       maxAge: 28,
     },

--- a/src/stories/pages/GatheringDetail/GatheringGuide.stories.tsx
+++ b/src/stories/pages/GatheringDetail/GatheringGuide.stories.tsx
@@ -20,7 +20,7 @@ export const Default: Story = {
       minParticipants: 2,
       maxParticipants: 4,
       categories: ['전략게임', '워게임'],
-      isAllowedAppositeGender: '혼성',
+      allowedGender: '남성',
       minAge: 21,
       maxAge: 28,
     },

--- a/src/stories/pages/GatheringDetail/GatheringGuide.stories.tsx
+++ b/src/stories/pages/GatheringDetail/GatheringGuide.stories.tsx
@@ -15,8 +15,10 @@ type Story = StoryObj<typeof GatheringGuide>;
 export const Default: Story = {
   args: {
     gatheringGuide: {
-      startTime: '토요일 오후',
+      time: '토요일 오후',
+      startTime: '',
       place: '사당역 근처 레드버튼',
+      subwayStation: '사당역',
       minParticipants: 2,
       maxParticipants: 4,
       categories: ['전략게임', '워게임'],

--- a/src/stories/pages/GatheringDetail/GatheringIntroduce.stories.tsx
+++ b/src/stories/pages/GatheringDetail/GatheringIntroduce.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import GatheringIntroduce from '@/pages/GatheringDetail/GatheringIntroduce/index';
+
+const meta: Meta<typeof GatheringIntroduce> = {
+  title: 'Pages/GatheringDetail/GatheringIntroduce',
+  tags: ['autodocs'],
+  component: GatheringIntroduce,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof GatheringIntroduce>;
+
+export const Default: Story = {
+  args: {
+    imageUrl: 'https://picsum.photos/200/200',
+  },
+};

--- a/src/stories/pages/GatheringDetail/GatheringIntroduce.stories.tsx
+++ b/src/stories/pages/GatheringDetail/GatheringIntroduce.stories.tsx
@@ -1,11 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import GatheringIntroduce from '@/pages/GatheringDetail/GatheringIntroduce/index';
+import { CommonPageLayoutDecorator } from '@/stories/CommonPageLayoutDecorator';
 
 const meta: Meta<typeof GatheringIntroduce> = {
   title: 'Pages/GatheringDetail/GatheringIntroduce',
   tags: ['autodocs'],
   component: GatheringIntroduce,
+  decorators: [CommonPageLayoutDecorator],
 };
 
 export default meta;


### PR DESCRIPTION
## 💬 Issue Number

> closes #63 

## 🤷‍♂️ Description

> 모임소개 페이지와 탭 UI를 구현하였습니다.


## 📷 Screenshots

https://github.com/BoardSignal/Team-CivilWar-BoardSignal-FE/assets/99376069/46eab20d-b359-4e73-b017-4e28d0dd1a08




## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 📒 Remarks
> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항
- 작성된 시간이 나오는 부분은 아직 구현하지 못했습니다.
- 참가자 탭의 참가자 수가 나오는 부분도 구현하지 못했습니다.
- 유저 프로필이 머지되면 모임소개와 참가자 페이지도 추가로 구현하겠습니다.
- 더미데이터에 값을 넣어 확인하였습니다. 추후에 실제 데이터 값이 들어갈 수 있도록 수정하겠습니다.
- 잘못된 코드가 있다면 알려주세요!