### PR TITLE
[#95] Feat: BadRequest Response Body에 code 필드 추가하기

### DIFF
--- a/src/apis/core/makeMutationResponse.ts
+++ b/src/apis/core/makeMutationResponse.ts
@@ -12,6 +12,7 @@ interface BadRequestResponse {
   isBadRequest: true;
   data: {
     message: string;
+    code: string;
   };
 }
 


### PR DESCRIPTION
resolves #95

## 🤷‍♂️ Description

`isBadRequest`일 때의 response body의 필드가 `message` 뿐이던 것에서 `code`도 추가되었습니다 :)