### PR TITLE
[#93] Feat: 모임 상세 페이지 - 참가자 목록

### DIFF
--- a/src/components/UserProfile/index.tsx
+++ b/src/components/UserProfile/index.tsx
@@ -1,3 +1,4 @@
+import Icon from '../Icon';
 import UserSignalTemperature from './UserSignalTemperature';
 
 interface UserProfileProps {
@@ -5,6 +6,7 @@ interface UserProfileProps {
   profileImageUrl?: string;
   ageGroup: string;
   signalTemperature: number;
+  isLeader: boolean;
 }
 
 const DEFAULT_PROFILE_IMAGE_URL = 'https://picsum.photos/200/200';
@@ -14,9 +16,10 @@ const UserProfile = ({
   profileImageUrl = DEFAULT_PROFILE_IMAGE_URL,
   ageGroup,
   signalTemperature,
+  isLeader,
 }: UserProfileProps) => {
   return (
-    <div className='flex'>
+    <div className='m-2 flex border-b border-gray-accent7 p-2'>
       <img
         src={profileImageUrl}
         alt='프로필사진'
@@ -24,9 +27,13 @@ const UserProfile = ({
       />
       <div className='flex w-full justify-between'>
         <div className='flex flex-col'>
-          <span className='text-[14px] font-bold text-gray-accent1'>
+          <span className='flex gap-2 text-[14px] font-bold text-gray-accent1'>
             {nickname}
+            {isLeader && (
+              <Icon id='vip-crown-fill' className='size-5 text-primary' />
+            )}
           </span>
+
           <span className='text-xs text-gray-accent2'>{ageGroup}</span>
         </div>
         <UserSignalTemperature temperature={signalTemperature} />

--- a/src/components/UserProfile/index.tsx
+++ b/src/components/UserProfile/index.tsx
@@ -2,43 +2,40 @@ import Icon from '../Icon';
 import UserSignalTemperature from './UserSignalTemperature';
 
 interface UserProfileProps {
-  nickname: string;
-  profileImageUrl?: string;
-  ageGroup: string;
-  signalTemperature: number;
-  isLeader: boolean;
+  userProfile: {
+    nickname: string;
+    profileImageUrl?: string;
+    ageGroup: string;
+    signalTemperature: number;
+    isLeader: boolean;
+  };
 }
 
-const DEFAULT_PROFILE_IMAGE_URL = 'https://picsum.photos/200/200';
+const UserProfile = ({ userProfile }: UserProfileProps) => {
+  const { nickname, profileImageUrl, ageGroup, signalTemperature, isLeader } =
+    userProfile;
 
-const UserProfile = ({
-  nickname,
-  profileImageUrl = DEFAULT_PROFILE_IMAGE_URL,
-  ageGroup,
-  signalTemperature,
-  isLeader,
-}: UserProfileProps) => {
   return (
-    <div className='m-2 flex border-b border-gray-accent7 p-2'>
-      <img
-        src={profileImageUrl}
-        alt='프로필사진'
-        className='mr-2 size-10 rounded-full object-cover'
-      />
-      <div className='flex w-full justify-between'>
+    <div className='flex items-center justify-between p-4'>
+      <div className='flex gap-2'>
+        <img
+          src={profileImageUrl}
+          alt='프로필사진'
+          className='size-10 rounded-full object-cover'
+        />
         <div className='flex flex-col'>
-          <span className='flex gap-2 text-[14px] font-bold text-gray-accent1'>
+          <span className='flex gap-2 text-sm font-bold text-gray-accent1'>
             {nickname}
             {isLeader && (
-              <Icon id='vip-crown-fill' className='size-5 text-primary' />
+              <Icon id='vip-crown-fill' size={20} className='text-primary' />
             )}
           </span>
-
           <span className='text-xs text-gray-accent2'>{ageGroup}</span>
         </div>
-        <UserSignalTemperature temperature={signalTemperature} />
       </div>
+      <UserSignalTemperature temperature={signalTemperature} />
     </div>
   );
 };
+
 export default UserProfile;

--- a/src/components/UserProfile/index.tsx
+++ b/src/components/UserProfile/index.tsx
@@ -1,7 +1,7 @@
 import Icon from '../Icon';
 import UserSignalTemperature from './UserSignalTemperature';
 
-interface UserProfileProps {
+export interface UserProfileProps {
   userProfile: {
     nickname: string;
     profileImageUrl?: string;

--- a/src/pages/GatheringDetail/GatheringParticipants/index.tsx
+++ b/src/pages/GatheringDetail/GatheringParticipants/index.tsx
@@ -2,6 +2,7 @@ import UserProfile from '@/components/UserProfile';
 
 export interface Participants {
   userId: number;
+  profileImageUrl?: string;
   nickname: string;
   ageGroup: string;
   isLeader: boolean;
@@ -19,13 +20,10 @@ const GatheringParticipants = ({
     <section className='grow overflow-y-auto'>
       <ul>
         {participants.map(participant => (
-          <UserProfile
-            key={participant.userId}
-            nickname={participant.nickname}
-            ageGroup={participant.ageGroup}
-            signalTemperature={participant.signalTemperature}
-            isLeader={participant.isLeader}
-          />
+          <li key={participant.userId}>
+            <UserProfile userProfile={participant} />
+            <div className='border-b border-gray-accent7'></div>
+          </li>
         ))}
       </ul>
     </section>

--- a/src/pages/GatheringDetail/GatheringParticipants/index.tsx
+++ b/src/pages/GatheringDetail/GatheringParticipants/index.tsx
@@ -4,7 +4,7 @@ export interface Participants {
   userId: number;
   nickname: string;
   ageGroup: string;
-  isLeader?: boolean;
+  isLeader: boolean;
   signalTemperature: number;
 }
 
@@ -24,6 +24,7 @@ const GatheringParticipants = ({
             nickname={participant.nickname}
             ageGroup={participant.ageGroup}
             signalTemperature={participant.signalTemperature}
+            isLeader={participant.isLeader}
           />
         ))}
       </ul>

--- a/src/pages/GatheringDetail/GatheringParticipants/index.tsx
+++ b/src/pages/GatheringDetail/GatheringParticipants/index.tsx
@@ -1,0 +1,34 @@
+import UserProfile from '@/components/UserProfile';
+
+export interface Participants {
+  userId: number;
+  nickname: string;
+  ageGroup: string;
+  isLeader?: boolean;
+  signalTemperature: number;
+}
+
+interface GatheringParticipantsProps {
+  participants: Participants[];
+}
+
+const GatheringParticipants = ({
+  participants,
+}: GatheringParticipantsProps) => {
+  return (
+    <section className='grow overflow-y-auto'>
+      <ul>
+        {participants.map(participant => (
+          <UserProfile
+            key={participant.userId}
+            nickname={participant.nickname}
+            ageGroup={participant.ageGroup}
+            signalTemperature={participant.signalTemperature}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default GatheringParticipants;

--- a/src/stories/components/UserProfile.stories.tsx
+++ b/src/stories/components/UserProfile.stories.tsx
@@ -12,11 +12,16 @@ export default meta;
 
 type Story = StoryObj<typeof UserProfile>;
 
+const DUMMY_USERPROFILE = {
+  nickname: '크라켄마스터',
+  profileImageUrl: 'https://picsum.photos/200/200',
+  ageGroup: '20대',
+  signalTemperature: 36.6,
+  isLeader: true,
+};
+
 export const Default: Story = {
   args: {
-    nickname: '크라켄마스터',
-    ageGroup: '20대',
-    signalTemperature: 36.6,
-    isLeader: true,
+    userProfile: DUMMY_USERPROFILE,
   },
 };

--- a/src/stories/components/UserProfile.stories.tsx
+++ b/src/stories/components/UserProfile.stories.tsx
@@ -13,5 +13,10 @@ export default meta;
 type Story = StoryObj<typeof UserProfile>;
 
 export const Default: Story = {
-  args: { nickname: '크라켄마스터', ageGroup: '20대', signalTemperature: 36.6 },
+  args: {
+    nickname: '크라켄마스터',
+    ageGroup: '20대',
+    signalTemperature: 36.6,
+    isLeader: true,
+  },
 };

--- a/src/stories/pages/GatheringDetail/GatheringParticipants.stories.tsx
+++ b/src/stories/pages/GatheringDetail/GatheringParticipants.stories.tsx
@@ -15,6 +15,7 @@ type Story = StoryObj<typeof GatheringParticipants>;
 const DUMMY_PARTICIPANTS = [
   {
     userId: 1,
+    profileImageUrl: 'https://picsum.photos/200/200',
     nickname: '인주니',
     ageGroup: '30대',
     isLeader: true,
@@ -22,6 +23,7 @@ const DUMMY_PARTICIPANTS = [
   },
   {
     userId: 2,
+    profileImageUrl: 'https://picsum.photos/200/200',
     nickname: '조로김강훈',
     ageGroup: '20대',
     isLeader: false,

--- a/src/stories/pages/GatheringDetail/GatheringParticipants.stories.tsx
+++ b/src/stories/pages/GatheringDetail/GatheringParticipants.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import GatheringParticipants from '@/pages/GatheringDetail/GatheringParticipants';
+
+const meta: Meta<typeof GatheringParticipants> = {
+  title: 'Pages/GatheringDetail/GatheringParticipants',
+  tags: ['autodocs'],
+  component: GatheringParticipants,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof GatheringParticipants>;
+
+const DUMMY_PARTICIPANTS = [
+  {
+    userId: 1,
+    nickname: '인주니',
+    ageGroup: '30대',
+    isLeader: true,
+    signalTemperature: 40,
+  },
+  {
+    userId: 2,
+    nickname: '조로김강훈',
+    ageGroup: '20대',
+    isLeader: false,
+    signalTemperature: 90,
+  },
+];
+export const Default: Story = {
+  args: {
+    participants: DUMMY_PARTICIPANTS,
+  },
+};


### PR DESCRIPTION
## 💬 Issue Number

> closes #93 

## 🤷‍♂️ Description

모임 상세 페이지의 참가자 목록을 구현하였습니다.

## 📷 Screenshots

<img width="590" alt="스크린샷 2024-03-06 오후 10 24 32" src="https://github.com/BoardSignal/Team-CivilWar-BoardSignal-FE/assets/99376069/b3e61dd6-6e86-42ab-9f58-138111936352">


## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 📒 Remarks
- 유저프로필 컴포넌트에서 누락되었던 방장 표시를 추가하였습니다.
- 부족하거나 잘못된 코드가 있다면 알려주세요! 
