### PR TITLE
Refactor: #88의 폼 코드 분리 제안

### DIFF
--- a/src/pages/GatheringCreate/components/GatheringCreateForm/formSchema.ts
+++ b/src/pages/GatheringCreate/components/GatheringCreateForm/formSchema.ts
@@ -1,0 +1,54 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import { array, boolean, mixed, number, object, string } from 'yup';
+
+import {
+  MAX_LENGTH_ERROR_MESSAGE,
+  MIN_LENGTH_ERROR_MESSAGE,
+  REQUIRED_ERROR_MESSAGE,
+  TRIM_ERROR_MESSAGE,
+} from '@/constants/messages/error';
+
+export const gatheringCreateSchema = object({
+  thumbnailImage: mixed<File>().required(),
+  roomTitle: string()
+    .required(REQUIRED_ERROR_MESSAGE)
+    .trim()
+    .min(2, `${TRIM_ERROR_MESSAGE}2${MIN_LENGTH_ERROR_MESSAGE}`)
+    .max(50, `50${MAX_LENGTH_ERROR_MESSAGE}`),
+  description: string()
+    .required(REQUIRED_ERROR_MESSAGE)
+    .trim()
+    .min(2, `${TRIM_ERROR_MESSAGE}2${MIN_LENGTH_ERROR_MESSAGE}`)
+    .max(500, `500${MAX_LENGTH_ERROR_MESSAGE}`),
+  isArrowedSameGender: boolean().required(),
+  headcount: array(number().required()).required().length(2),
+  time: string().required(REQUIRED_ERROR_MESSAGE),
+  startTime: string().defined(),
+  age: array(number().required()).required().length(2),
+  subwayLine: string().defined(),
+  subwayStation: string().required(REQUIRED_ERROR_MESSAGE),
+  place: string().defined(),
+  categories: array(string().defined()).required(),
+});
+
+export const gatheringCreateDefaultValue = {
+  thumbnailImage: new File([], ''),
+  roomTitle: '',
+  description: '',
+  isArrowedSameGender: false,
+  headcount: [1, 8],
+  time: '',
+  startTime: '',
+  // 사용자의 나이는 폼 컴포넌트에서 반영해요.
+  age: [10, 40],
+  subwayLine: '',
+  subwayStation: '',
+  place: '',
+  categories: [],
+};
+
+export const gatheringCreateFormOptions = {
+  mode: 'all',
+  defaultValues: gatheringCreateDefaultValue,
+  resolver: yupResolver(gatheringCreateSchema),
+} as const;

--- a/src/pages/GatheringCreate/components/GatheringCreateForm/gatheringCreateRequestMapper.ts
+++ b/src/pages/GatheringCreate/components/GatheringCreateForm/gatheringCreateRequestMapper.ts
@@ -1,0 +1,48 @@
+import { BOARDGAME_CATEGORIES } from '@/constants/boardgameCategories';
+
+export interface GatheringCreateFormValues {
+  thumbnailImage: File;
+  roomTitle: string;
+  description: string;
+  isArrowedSameGender: boolean;
+  headcount: number[];
+  time: string;
+  startTime: string;
+  age: number[];
+  subwayLine: string;
+  subwayStation: string;
+  place: string;
+  categories: string[];
+}
+
+const gatheringCreateRequestMapper = (data: GatheringCreateFormValues) => {
+  const {
+    thumbnailImage: imageFile,
+    isArrowedSameGender,
+    headcount: [minParticipants, maxParticipants],
+    time,
+    age: [minAge, maxAge],
+    categories,
+    ...restGathering
+  } = data;
+
+  const gathering = {
+    isAllowedOppositeGender: !isArrowedSameGender,
+    minParticipants,
+    maxParticipants,
+    day: time.split(' ')[0],
+    time: time.split(' ')[1],
+    minAge,
+    maxAge,
+    categories:
+      categories.length === 0 ? [...BOARDGAME_CATEGORIES] : categories,
+    ...restGathering,
+  };
+
+  return {
+    imageFile,
+    gathering,
+  };
+};
+
+export default gatheringCreateRequestMapper;

--- a/src/pages/GatheringCreate/components/GatheringCreateForm/useCreateGathering.ts
+++ b/src/pages/GatheringCreate/components/GatheringCreateForm/useCreateGathering.ts
@@ -1,0 +1,23 @@
+import {
+  GatheringCreateRequest,
+  usePostGatheringCreateApi,
+} from '@/apis/postGatheringCreate';
+import { showErrorToast } from '@/utils/showToast';
+
+import { OnGatheringCreate } from '.';
+
+const useCreateGathering = (onCreate: OnGatheringCreate) => {
+  const gatheringCreateApi = usePostGatheringCreateApi();
+
+  return async (request: GatheringCreateRequest) => {
+    const { data, isBadRequest } = await gatheringCreateApi(request);
+
+    if (isBadRequest) {
+      return showErrorToast(data.message);
+    }
+
+    onCreate(data.roomId);
+  };
+};
+
+export default useCreateGathering;


### PR DESCRIPTION
## 목적

#88 PR의 resolver 반영에 대한 폼 분리 제안이에요.

## 이유

긴 코드를 여러 파일로 나누는 코멘트여서 간단하게 리뷰 코멘트로 남기기가 어려워서 PR로 만들어서 올려요,,!

## 논의 방식 제안

이렇게 하면 좋을 것 같아요 :)
- 이 제안의 많은 코드가 채택이 되는 경우라면
  - 여기서 논의하고 제가 수정해서 76 브랜치에 머지후 76 머지
- 이 제안의 약간의 코드만 채택이 되는 경우라면
  - 여기서 논의하고 희라님이 수정해서 76 브랜치에서 수정하고 머지

## 변경 사항 설명

- schema에 관한 값들을 `./formSchema`로 모아놓았어요. 폼 설정은 해당 파일만 수정하면 돼요.
  - schem, useForm옵션, defaultValues
- API 전송 시 필요한 매핑을 `gatheringCreateRequestMapper`로 뺐어요. 폼 타입도 같이 뺐어요.
- `useCreateGathering`을 커스텀 훅으로 만들었어요.
- 현재 사용자의 나이대에 맞는 Range 설정은 상수로 하지 못해서 `useEffect`를 사용했어요.