### PR TITLE
[#101] Fix: 상대적 시간 정책 반영

### DIFF
--- a/src/components/GatheringList/GatheringListItem.tsx
+++ b/src/components/GatheringList/GatheringListItem.tsx
@@ -60,7 +60,7 @@ const GatheringListItem = ({ gathering }: GatheringListItemProps) => {
               <div className='text-xs text-gray-accent2'>{categoriesText}</div>
             </div>
             <div className='flex justify-between text-xs text-gray-accent3'>
-              <div>{getRelativeTime(createdAt)}</div>
+              <div>{getRelativeTime({ time: createdAt })}</div>
               <div className='flex items-center gap-1'>
                 <Icon id='user-line' size={12} />
                 <span>{headCount}</span>

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -27,7 +27,7 @@ export const getRelativeTime = ({ time, duration }: GetRelativeTimeProps) => {
     (new Date().getTime() - new Date(time).getTime()) / 60000;
 
   if (
-    duration &&
+    duration !== undefined &&
     minutesDifference >= duration * MINUTES_PER_TIME_UNIT[3].minutes
   ) {
     return new Intl.DateTimeFormat('ko-KR').format(new Date(time));

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -4,22 +4,38 @@ type MinutesPerTimeUnit = {
   minutes: number;
 };
 
-export const getRelativeTime = (time: string) => {
-  const formatter = new Intl.RelativeTimeFormat('ko', {
-    numeric: 'always',
-  });
+const MINUTES_PER_TIME_UNIT: MinutesPerTimeUnit[] = [
+  { unit: 'year', minutes: 60 * 24 * 365 },
+  { unit: 'month', minutes: 60 * 24 * 30 },
+  { unit: 'week', minutes: 60 * 24 * 7 },
+  { unit: 'day', minutes: 60 * 24 },
+  { unit: 'hour', minutes: 60 },
+  { unit: 'minute', minutes: 1 },
+];
 
+interface GetRelativeTimeProps {
+  time: string;
+  duration?: number;
+}
+
+/**
+ * time은 yyyy-mm-ddThh:mm:ss, yyyy/mm/dd hh:mm:ss 포맷만 가능합니다.
+ * duration은 상대적 시간을 표시하는 지속 기간으로, 단위는 일(day)입니다.
+ */
+export const getRelativeTime = ({ time, duration }: GetRelativeTimeProps) => {
   const minutesDifference =
     (new Date().getTime() - new Date(time).getTime()) / 60000;
 
-  const MINUTES_PER_TIME_UNIT: MinutesPerTimeUnit[] = [
-    { unit: 'year', minutes: 60 * 24 * 365 },
-    { unit: 'month', minutes: 60 * 24 * 30 },
-    { unit: 'week', minutes: 60 * 24 * 7 },
-    { unit: 'day', minutes: 60 * 24 },
-    { unit: 'hour', minutes: 60 },
-    { unit: 'minute', minutes: 1 },
-  ];
+  if (
+    duration &&
+    minutesDifference >= duration * MINUTES_PER_TIME_UNIT[3].minutes
+  ) {
+    return new Intl.DateTimeFormat('ko-KR').format(new Date(time));
+  }
+
+  const formatter = new Intl.RelativeTimeFormat('ko', {
+    numeric: 'always',
+  });
 
   for (const { unit, minutes } of MINUTES_PER_TIME_UNIT) {
     const calculatedTime = Math.floor(minutesDifference / minutes);


### PR DESCRIPTION
## 💬 Issue Number

> closes #101 

## 🤷‍♂️ Description
- 모임 상세 페이지: 일주일이 지나면 실제 날짜 표시
- 진행한 모임 목록 페이지: 실제 날짜 표시
- 나머지 페이지: 상대적 시간 표시

정책에 따라 `getRelativeTime` 함수에 `duration` 옵션을 추가했습니다.

## 👻 Good Function
### 사용법
`duration` 단위는 일(day)입니다. 
```javascript
// 모임 상세 페이지
getRelativeTime({ time: createdAt, duration: 7 })

// 진행한 모임 목록 페이지
getRelativeTime({ time: createdAt, duration: 0 })

// 나머지 페이지
getRelativeTime({ time: createdAt })
```

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 📒 Remarks
- `Date` 객체 포맷에 맞지 않는 값이 들어오는 경우 어떤 값을 화면에 보여주어야 할지 잘 모르겠습니다. (현재 처리가 안 되어있고, `방금 전`으로 뜨게 됩니다) 좋은 아이디어가 있다면 나눠주세요!
- 인수를 지금처럼 객체로 넘겨주는 것과 각각 값을 넘겨주는 것 중 어떤 방식이 더 좋을까요?
  ```javascript
  getRelativeTime({ time: createdAt, duration: 7 })
  getRelativeTime(createdAt, 7)
  ```
