### PR TITLE
[#124] Refactor: Chromatic 배포 환경의 baseUrl을 GitHub Action 환경 변수를 쓰도록 변경

### DIFF
--- a/.github/workflows/publish-storybook.yaml
+++ b/.github/workflows/publish-storybook.yaml
@@ -24,5 +24,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           exitZeroOnChanges: true
         env:
-          STORYBOOK_BASE_URL: https://api.boardsignal.com/api/v1
+          STORYBOOK_BASE_URL: ${{ env.STORYBOOK_BASE_URL }}
           STORYBOOK_KAKAO_MAP_ACCESS_KEY: ${{ secrets.STORYBOOK_KAKAO_MAP_ACCESS_KEY }}

--- a/.github/workflows/publish-storybook.yaml
+++ b/.github/workflows/publish-storybook.yaml
@@ -24,5 +24,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           exitZeroOnChanges: true
         env:
-          STORYBOOK_BASE_URL: ${{ env.STORYBOOK_BASE_URL }}
+          STORYBOOK_BASE_URL: ${{ vars.STORYBOOK_BASE_URL }}
           STORYBOOK_KAKAO_MAP_ACCESS_KEY: ${{ secrets.STORYBOOK_KAKAO_MAP_ACCESS_KEY }}


### PR DESCRIPTION
resolves #124

## 🤷‍♂️ Description

아주 단순한 변경입니다 :)

- 스토리북 배포 시 GitHub Action의 variable 설정에 따라 환경 변수를 지정하게 돼요.

before:
```
STORYBOOK_BASE_URL: https://api.boardsignal.com/api/v1
```

after:
```
STORYBOOK_BASE_URL: ${{ vars.STORYBOOK_BASE_URL }}