### PR TITLE
[#138] Feat: 보드게임 목록 페이지 

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -25,6 +25,7 @@ import ProfilePage from '@/pages/Profile';
 import RedirectOnAuthentication from '@/pages/RedirectOnAuthentication';
 
 import SpinnerFullScreen from './components/Spinner/SpinnerFullScreen';
+import BoardGameListPage from './pages/BoardGameList';
 import GatheringFixPage from './pages/GatheringFix';
 import GatheringListPage from './pages/GatheringList';
 import ProfileEdit from './pages/ProfileEdit';
@@ -74,7 +75,7 @@ const AnimatedRoutes = () => {
             path={BOARD_GAMES_PAGE_URL}
             element={
               <Suspense fallback={<SpinnerFullScreen />}>
-                <HomePage />
+                <BoardGameListPage />
               </Suspense>
             }
           />

--- a/src/apis/boardGameList.ts
+++ b/src/apis/boardGameList.ts
@@ -1,0 +1,56 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import qs from 'qs';
+
+import { BoardGameCategories } from '@/constants/options';
+import { BOARD_GAMES_PAGE_URL } from '@/constants/pageRoutes';
+import { BOARD_GAME_LIST_QUERY_KEY } from '@/constants/queryKey';
+
+import { api } from './core';
+
+export interface BoardGameListItemResponseDTO {
+  boardGameId: number;
+  name: string;
+  categories: BoardGameCategories[];
+  difficulty: string;
+  minParticipants: number;
+  maxParticipants: number;
+  fromPlayTime: number;
+  toPlayTime: number;
+  wishCount: number;
+  imageUrl: string | null;
+}
+
+interface BoardGameListResponseDTO {
+  boardGamesInfos: BoardGameListItemResponseDTO[];
+  currentPageNumber: number;
+  size: number;
+  hasNext: true;
+}
+
+interface BoardGameListFilterOptions {
+  difficulty?: string;
+  categories?: string[];
+  playTime?: number;
+  searchKeyword?: string;
+}
+
+const getBoardGameList = (options: BoardGameListFilterOptions) =>
+  api.get<BoardGameListResponseDTO>({
+    url: BOARD_GAMES_PAGE_URL,
+    params: options,
+    // indices 옵션에 따라 아래와 같이 변환돼요.
+    // indices=true(기본) --> 'a[0]=b&a[1]=c&a[2]=d'
+    // indices=false      --> 'a=b&a=c&a=d'
+    paramsSerializer: params => qs.stringify(params, { indices: false }),
+  });
+
+export const useGetBoardGameListApi = (options: BoardGameListFilterOptions) => {
+  const {
+    data: { boardGamesInfos },
+  } = useSuspenseQuery({
+    queryKey: [BOARD_GAME_LIST_QUERY_KEY, options],
+    queryFn: () => getBoardGameList(options),
+  });
+
+  return boardGamesInfos;
+};

--- a/src/apis/notifications.ts
+++ b/src/apis/notifications.ts
@@ -115,9 +115,9 @@ export const useGetNotificationsApi = (size: number = 20) => {
         hasNext ? currentPage + 1 : undefined,
     });
 
-  const allPagesMerged = data.pages
-    .map(({ notificationsInfos }) => notificationsInfos)
-    .flat();
+  const allPagesMerged = data.pages.flatMap(
+    ({ notificationsInfos }) => notificationsInfos,
+  );
 
   return {
     fetchStatus,

--- a/src/components/OptionFilterBar/index.tsx
+++ b/src/components/OptionFilterBar/index.tsx
@@ -20,9 +20,10 @@ export interface Option {
 
 interface OptionFilterBarProps {
   options: Option[];
+  resetUrl?: string;
 }
 
-const OptionFilterBar = ({ options }: OptionFilterBarProps) => {
+const OptionFilterBar = ({ options, resetUrl = '/' }: OptionFilterBarProps) => {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const handleToggleButton = (queryStringKey: string, optionItem: string) => {
@@ -36,7 +37,7 @@ const OptionFilterBar = ({ options }: OptionFilterBarProps) => {
   return (
     <section className='scroll-none flex shrink-0 items-center overflow-x-auto whitespace-nowrap border-b border-gray-accent7 px-4 py-2'>
       <div className='flex w-max items-center gap-2'>
-        <Link to='/'>
+        <Link to={resetUrl}>
           <Button className='flex h-fit w-fit rounded-full bg-gray-accent7 p-2'>
             <Icon id='close-line' size={16} className='text-gray-accent2' />
           </Button>

--- a/src/constants/messages/emptyScreens.ts
+++ b/src/constants/messages/emptyScreens.ts
@@ -1,3 +1,6 @@
 export const EMPTY_NOTIFICATION_TITLE = '앗! 아무 알림이 없어요!';
 export const EMPTY_NOTIFICATION_MESSAGE =
   '여러 활동들을 하시면 자연스럽게 알림이 생길 거에요';
+
+export const EMPTY_BOARD_GAMES_TITLE = '앗! 조건에 맞는 게임이 없어요!';
+export const EMPTY_BOARD_GAMES_MESSAGE = '조건을 변경해서 검색해주세요';

--- a/src/constants/options.ts
+++ b/src/constants/options.ts
@@ -15,3 +15,15 @@ export const BOARDGAME_CATEGORIES = [
   '어린이게임',
   '컬렉터블게임',
 ];
+
+export type BoardGameCategories =
+  | '워게임'
+  | '가족게임'
+  | '전략게임'
+  | '추상게임'
+  | '테마게임'
+  | '파티게임'
+  | '어린이게임'
+  | '컬렉터블게임';
+
+export const DIFFICULTY_CATEGORIES = ['쉬움', '보통', '어려움'];

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -1,6 +1,7 @@
 export const LOGGED_IN_USER_QUERY_KEY = 'logged-in-user';
 export const GATHERING_DETAIL_QUERY_KEY = 'gathering-detail';
 export const BOARD_GAME_DETAIL_QUERY_KEY = 'board-game-detail';
+export const BOARD_GAME_LIST_QUERY_KEY = 'board-games';
 export const NOTIFICATIONS_QUERY_KEY = 'notifications';
 export const PROFILES_QUERY_KEY = 'profiles';
 export const KAKAO_MAP_SEARCH_QUERY_KEY = 'kakao-map-search';

--- a/src/mocks/boardGameList.tsx
+++ b/src/mocks/boardGameList.tsx
@@ -32,16 +32,28 @@ const boardGameList = [
   {
     boardGameId: 3,
     name: 'Board Game 3',
-    categories: ['가족게임'],
+    categories: ['커플인기', '더지니어스'],
     difficulty: '어려움',
     minParticipants: 2,
     maxParticipants: 8,
-    fromPlayTime: 45,
-    toPlayTime: 120,
+    fromPlayTime: 125,
+    toPlayTime: 140,
     wishCount: 80,
     imageUrl: 'https://picsum.photos/seed/3/200/300',
   },
 ];
+
+// 긴 Mock이 필요해서 반복해서 만들었어요
+const repeatedboardGameList = [
+  ...boardGameList,
+  ...boardGameList,
+  ...boardGameList,
+].map((item, idx) => ({
+  ...item,
+  boardGameId: idx + 1,
+  imageUrl: `https://picsum.photos/seed/${idx}/200/300`,
+  name: `Board Game ${idx}`,
+}));
 
 export const mockGetNotificationsHandler: HttpResponseResolver = async ({
   request,
@@ -53,7 +65,7 @@ export const mockGetNotificationsHandler: HttpResponseResolver = async ({
 
   // 필터링을 흉내내서 조금 복잡해요.
   return HttpResponse.json({
-    boardGamesInfos: boardGameList.filter(item => {
+    boardGamesInfos: repeatedboardGameList.filter(item => {
       if (difficulty && item.difficulty !== difficulty) {
         return false;
       }

--- a/src/mocks/boardGameList.tsx
+++ b/src/mocks/boardGameList.tsx
@@ -1,0 +1,85 @@
+import { HttpResponse, HttpResponseResolver, http } from 'msw';
+
+import { API_BASE_URL, BOARD_GAMES_API_URL } from '@/constants/apiRoutes';
+
+export const MOCK_GET_NOTIFICATIONS_URL = `${API_BASE_URL}${BOARD_GAMES_API_URL}`;
+
+const boardGameList = [
+  {
+    boardGameId: 1,
+    name: 'Board Game 1',
+    categories: ['워게임'],
+    difficulty: '보통',
+    minParticipants: 2,
+    maxParticipants: 6,
+    fromPlayTime: 30,
+    toPlayTime: 90,
+    wishCount: 101,
+    imageUrl: 'https://picsum.photos/seed/1/200/300',
+  },
+  {
+    boardGameId: 2,
+    name: 'Board Game 2',
+    categories: ['파티게임'],
+    difficulty: '쉬움',
+    minParticipants: 1,
+    maxParticipants: 4,
+    fromPlayTime: 20,
+    toPlayTime: 60,
+    wishCount: 50,
+    imageUrl: 'https://picsum.photos/seed/2/200/300',
+  },
+  {
+    boardGameId: 3,
+    name: 'Board Game 3',
+    categories: ['가족게임'],
+    difficulty: '어려움',
+    minParticipants: 2,
+    maxParticipants: 8,
+    fromPlayTime: 45,
+    toPlayTime: 120,
+    wishCount: 80,
+    imageUrl: 'https://picsum.photos/seed/3/200/300',
+  },
+];
+
+export const mockGetNotificationsHandler: HttpResponseResolver = async ({
+  request,
+}) => {
+  const url = new URL(request.url);
+  const difficulty = url.searchParams.get('difficulty');
+  const playTimeString = url.searchParams.get('playTime');
+  const categories = url.searchParams.getAll('categories');
+
+  // 필터링을 흉내내서 조금 복잡해요.
+  return HttpResponse.json({
+    boardGamesInfos: boardGameList.filter(item => {
+      if (difficulty && item.difficulty !== difficulty) {
+        return false;
+      }
+      if (playTimeString) {
+        const playTime = parseInt(playTimeString, 10);
+        if (playTime < item.fromPlayTime || playTime > item.toPlayTime) {
+          return false;
+        }
+      }
+      if (
+        categories &&
+        categories.find(category => !item.categories.includes(category))
+      ) {
+        return false;
+      }
+
+      return true;
+    }),
+    currentPageNumber: 0,
+    size: 20,
+    hasNext: false,
+  });
+};
+
+const boardGameListMocks = [
+  http.get(MOCK_GET_NOTIFICATIONS_URL, mockGetNotificationsHandler),
+];
+
+export default boardGameListMocks;

--- a/src/pages/BoardGameList/components/BoardGameList/BoardGameListItem.tsx
+++ b/src/pages/BoardGameList/components/BoardGameList/BoardGameListItem.tsx
@@ -1,13 +1,13 @@
 import { Link } from 'react-router-dom';
 
-import { BoardGameListItemResponseDTO } from '@/apis/boardGameList';
+import { BoardGameListItemResponse } from '@/apis/boardGameList';
 import Button from '@/components/Button';
 import Chip from '@/components/Chip';
 import Icon from '@/components/Icon';
 import { BOARD_GAMES_PAGE_URL } from '@/constants/pageRoutes';
 
 type BoardGameListItemProps = {
-  boardGame: BoardGameListItemResponseDTO;
+  boardGame: BoardGameListItemResponse;
 };
 
 interface DescriptionProps {

--- a/src/pages/BoardGameList/components/BoardGameList/BoardGameListItem.tsx
+++ b/src/pages/BoardGameList/components/BoardGameList/BoardGameListItem.tsx
@@ -56,19 +56,20 @@ const BoardGameListItem = ({
           className='size-[100px] rounded-lg border border-gray-accent7 object-contain'
         />
         <div className='flex flex-col items-start gap-2'>
-          <div className='flex flex-col gap-1'>
+          <div className='flex flex-col items-start gap-1'>
             <span className='font-bold text-gray-accent1'>{name}</span>
             <div className='flex gap-1'>
-              {/* 카테고리가 여러 개 인 경우의 디자인이 없어서 gap: 4px로 지정했어요 */}
               {categories.map(category => (
                 <Chip key={category}>{category}</Chip>
               ))}
             </div>
           </div>
-          <div className='flex gap-1'>
+          <div className='flex flex-col gap-1'>
+            <div className='flex gap-1'>
+              <Description title='인원' value={participantsText} />
+              <Description title='소요시간' value={playTimeText} />
+            </div>
             <Description title='난이도' value={difficulty} />
-            <Description title='인원' value={participantsText} />
-            <Description title='소요시간' value={playTimeText} />
           </div>
           <div className='flex items-center gap-2 py-0.5'>
             <Icon

--- a/src/pages/BoardGameList/components/BoardGameList/BoardGameListItem.tsx
+++ b/src/pages/BoardGameList/components/BoardGameList/BoardGameListItem.tsx
@@ -1,7 +1,10 @@
+import { Link } from 'react-router-dom';
+
 import { BoardGameListItemResponseDTO } from '@/apis/boardGameList';
 import Button from '@/components/Button';
 import Chip from '@/components/Chip';
 import Icon from '@/components/Icon';
+import { BOARD_GAMES_PAGE_URL } from '@/constants/pageRoutes';
 
 type BoardGameListItemProps = {
   boardGame: BoardGameListItemResponseDTO;
@@ -23,6 +26,7 @@ const DEFAULT_BOARD_GAME_IMAGE_URL = 'https://picsum.photos/200/300';
 
 const BoardGameListItem = ({
   boardGame: {
+    boardGameId,
     name,
     categories,
     difficulty,
@@ -34,39 +38,48 @@ const BoardGameListItem = ({
     imageUrl,
   },
 }: BoardGameListItemProps) => {
+  const participantsText =
+    minParticipants === maxParticipants
+      ? minParticipants.toString()
+      : [minParticipants, maxParticipants].join('-');
+
+  const playTimeText =
+    fromPlayTime === toPlayTime
+      ? fromPlayTime.toString()
+      : `${[fromPlayTime, toPlayTime].join('-')}분`;
+
   return (
-    <Button className='flex h-fit justify-start gap-4 rounded-none p-4'>
-      <img
-        src={imageUrl ?? DEFAULT_BOARD_GAME_IMAGE_URL}
-        className='size-[100px] rounded-lg border border-gray-accent7 object-contain'
-      />
-      <div className='flex flex-col items-start gap-2'>
-        <div className='flex flex-col gap-1'>
-          <span className='font-bold text-gray-accent1'>{name}</span>
+    <Link to={`${BOARD_GAMES_PAGE_URL}/${boardGameId}`}>
+      <Button className='flex h-fit justify-start gap-4 rounded-none border-b border-gray-accent7 p-4'>
+        <img
+          src={imageUrl ?? DEFAULT_BOARD_GAME_IMAGE_URL}
+          className='size-[100px] rounded-lg border border-gray-accent7 object-contain'
+        />
+        <div className='flex flex-col items-start gap-2'>
+          <div className='flex flex-col gap-1'>
+            <span className='font-bold text-gray-accent1'>{name}</span>
+            <div className='flex gap-1'>
+              {/* 카테고리가 여러 개 인 경우의 디자인이 없어서 gap: 4px로 지정했어요 */}
+              {categories.map(category => (
+                <Chip key={category}>{category}</Chip>
+              ))}
+            </div>
+          </div>
           <div className='flex gap-1'>
-            {/* 카테고리가 여러 개 인 경우의 디자인이 없어서 gap: 4px로 지정했어요 */}
-            {categories.map(category => (
-              <Chip key={category}>{category}</Chip>
-            ))}
+            <Description title='난이도' value={difficulty} />
+            <Description title='인원' value={participantsText} />
+            <Description title='소요시간' value={playTimeText} />
+          </div>
+          <div className='flex items-center gap-2 py-0.5'>
+            <Icon
+              id='bookmark-line'
+              className='size-[14px] text-gray-accent1'
+            />
+            <span className='text-xs text-gray-accent2'>{wishCount}</span>
           </div>
         </div>
-        <div className='flex gap-1'>
-          <Description title='난이도' value={difficulty} />
-          <Description
-            title='인원'
-            value={[minParticipants, maxParticipants].join('-')}
-          />
-          <Description
-            title='소요시간'
-            value={`${[fromPlayTime, toPlayTime].join('-')}분`}
-          />
-        </div>
-        <div className='flex gap-2 py-0.5'>
-          <Icon id='bookmark-line' className='size-[14px] text-gray-accent1' />
-          <span className='text-xs text-gray-accent2'>{wishCount}</span>
-        </div>
-      </div>
-    </Button>
+      </Button>
+    </Link>
   );
 };
 

--- a/src/pages/BoardGameList/components/BoardGameList/BoardGameListItem.tsx
+++ b/src/pages/BoardGameList/components/BoardGameList/BoardGameListItem.tsx
@@ -1,0 +1,73 @@
+import { BoardGameListItemResponseDTO } from '@/apis/boardGameList';
+import Button from '@/components/Button';
+import Chip from '@/components/Chip';
+import Icon from '@/components/Icon';
+
+type BoardGameListItemProps = {
+  boardGame: BoardGameListItemResponseDTO;
+};
+
+interface DescriptionProps {
+  title: string;
+  value: string;
+}
+
+const Description = ({ title, value }: DescriptionProps) => (
+  <div className='flex gap-0.5'>
+    <span className='text-xs font-bold text-gray-accent1'>{title}</span>
+    <span className='text-xs text-gray-accent2'>{value}</span>
+  </div>
+);
+
+const DEFAULT_BOARD_GAME_IMAGE_URL = 'https://picsum.photos/200/300';
+
+const BoardGameListItem = ({
+  boardGame: {
+    name,
+    categories,
+    difficulty,
+    minParticipants,
+    maxParticipants,
+    fromPlayTime,
+    toPlayTime,
+    wishCount,
+    imageUrl,
+  },
+}: BoardGameListItemProps) => {
+  return (
+    <Button className='flex h-fit justify-start gap-4 rounded-none p-4'>
+      <img
+        src={imageUrl ?? DEFAULT_BOARD_GAME_IMAGE_URL}
+        className='size-[100px] rounded-lg border border-gray-accent7 object-contain'
+      />
+      <div className='flex flex-col items-start gap-2'>
+        <div className='flex flex-col gap-1'>
+          <span className='font-bold text-gray-accent1'>{name}</span>
+          <div className='flex gap-1'>
+            {/* 카테고리가 여러 개 인 경우의 디자인이 없어서 gap: 4px로 지정했어요 */}
+            {categories.map(category => (
+              <Chip key={category}>{category}</Chip>
+            ))}
+          </div>
+        </div>
+        <div className='flex gap-1'>
+          <Description title='난이도' value={difficulty} />
+          <Description
+            title='인원'
+            value={[minParticipants, maxParticipants].join('-')}
+          />
+          <Description
+            title='소요시간'
+            value={`${[fromPlayTime, toPlayTime].join('-')}분`}
+          />
+        </div>
+        <div className='flex gap-2 py-0.5'>
+          <Icon id='bookmark-line' className='size-[14px] text-gray-accent1' />
+          <span className='text-xs text-gray-accent2'>{wishCount}</span>
+        </div>
+      </div>
+    </Button>
+  );
+};
+
+export default BoardGameListItem;

--- a/src/pages/BoardGameList/components/BoardGameList/index.tsx
+++ b/src/pages/BoardGameList/components/BoardGameList/index.tsx
@@ -1,24 +1,42 @@
 import { useGetBoardGameListApi } from '@/apis/boardGameList';
+import EmptyListFullScreen from '@/components/EmptyListFullScreen';
+import InfiniteScrollAutoFetcher from '@/components/InfiniteScrollAutoFetcher';
+import {
+  EMPTY_BOARD_GAMES_MESSAGE,
+  EMPTY_BOARD_GAMES_TITLE,
+} from '@/constants/messages/emptyScreens';
 
 import { useBoardGameListQueryParams } from '../../hooks/useBoardGameListQueryParams';
 import BoardGameListItem from './BoardGameListItem';
 
 const BoardGameList = () => {
   const options = useBoardGameListQueryParams();
-  const data = useGetBoardGameListApi(options);
 
-  // TODO: EmptyListFullScreen 추가하기
+  const { boardGamesInfos, fetchStatus, hasNextPage, fetchNextPage } =
+    useGetBoardGameListApi(options);
+
+  if (boardGamesInfos.length === 0) {
+    return (
+      <EmptyListFullScreen
+        title={EMPTY_BOARD_GAMES_TITLE}
+        message={EMPTY_BOARD_GAMES_MESSAGE}
+      />
+    );
+  }
 
   return (
-    <div className='grow overflow-y-auto'>
-      <ul>
-        {data.map(boardGame => (
-          <li key={boardGame.boardGameId}>
-            <BoardGameListItem boardGame={boardGame} />
-          </li>
-        ))}
-      </ul>
-    </div>
+    <InfiniteScrollAutoFetcher
+      fetchStatus={fetchStatus}
+      hasNextPage={hasNextPage}
+      fetchNextPage={fetchNextPage}
+      className='flex flex-col'
+    >
+      {boardGamesInfos.map(boardGame => (
+        <li key={boardGame.boardGameId}>
+          <BoardGameListItem boardGame={boardGame} />
+        </li>
+      ))}
+    </InfiniteScrollAutoFetcher>
   );
 };
 

--- a/src/pages/BoardGameList/components/BoardGameList/index.tsx
+++ b/src/pages/BoardGameList/components/BoardGameList/index.tsx
@@ -1,0 +1,25 @@
+import { useGetBoardGameListApi } from '@/apis/boardGameList';
+
+import { useBoardGameListQueryParams } from '../../hooks/useBoardGameListQueryParams';
+import BoardGameListItem from './BoardGameListItem';
+
+const BoardGameList = () => {
+  const options = useBoardGameListQueryParams();
+  const data = useGetBoardGameListApi(options);
+
+  // TODO: EmptyListFullScreen 추가하기
+
+  return (
+    <div className='grow overflow-y-auto'>
+      <ul>
+        {data.map(boardGame => (
+          <li key={boardGame.boardGameId}>
+            <BoardGameListItem boardGame={boardGame} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default BoardGameList;

--- a/src/pages/BoardGameList/components/BoardGameList/index.tsx
+++ b/src/pages/BoardGameList/components/BoardGameList/index.tsx
@@ -32,9 +32,7 @@ const BoardGameList = () => {
       className='flex flex-col'
     >
       {boardGamesInfos.map(boardGame => (
-        <li key={boardGame.boardGameId}>
-          <BoardGameListItem boardGame={boardGame} />
-        </li>
+        <BoardGameListItem key={boardGame.boardGameId} boardGame={boardGame} />
       ))}
     </InfiniteScrollAutoFetcher>
   );

--- a/src/pages/BoardGameList/components/BoardGameListOptionFilterBar/index.tsx
+++ b/src/pages/BoardGameList/components/BoardGameListOptionFilterBar/index.tsx
@@ -1,0 +1,45 @@
+import OptionFilterBar from '@/components/OptionFilterBar';
+import {
+  BOARDGAME_CATEGORIES,
+  DIFFICULTY_CATEGORIES,
+} from '@/constants/options';
+import { BOARD_GAMES_PAGE_URL } from '@/constants/pageRoutes';
+
+const OPTIONS = [
+  {
+    name: '난이도',
+    icon: 'bar-chart',
+    items: DIFFICULTY_CATEGORIES,
+    queryStringKey: 'difficulty',
+    selectLimit: 1,
+  },
+  {
+    name: '시간',
+    icon: 'time',
+    // TODO: 임의의 시간 값들을 만들어놓았어요.
+    items: [15, 30, 45, 60, 80, 100, 120].map(String),
+    // FIXME: option의 value와 text의 분리를 할 수가 없어요.
+    // FIXME: 범위 중간에 속하면 결과에 포함되는데..뭔가 이상한 것 같아요.
+    // --> Range로 선택하면 좋을 것 같아요.
+    // .map(
+    //   min => `${min}분`,
+    // ),
+    queryStringKey: 'playTime',
+    selectLimit: 1,
+  },
+  {
+    name: '카테고리',
+    icon: 'gamepad',
+    items: BOARDGAME_CATEGORIES,
+    queryStringKey: 'categories',
+    selectLimit: 3,
+  },
+  // FIXME: API 명세에 인원 수가 없는 것 같아요.
+  // --> 인원 수도 Range로 선택하면 좋을 것 같아요.
+];
+
+const BoardGameListOptionFilterBar = () => (
+  <OptionFilterBar options={OPTIONS} resetUrl={BOARD_GAMES_PAGE_URL} />
+);
+
+export default BoardGameListOptionFilterBar;

--- a/src/pages/BoardGameList/hooks/useBoardGameListQueryParams/index.tsx
+++ b/src/pages/BoardGameList/hooks/useBoardGameListQueryParams/index.tsx
@@ -1,0 +1,43 @@
+import qs from 'qs';
+import { useSearchParams } from 'react-router-dom';
+import { mixed, object, string } from 'yup';
+
+import InvalidStatePageError from '@/components/ErrorAlertFullScreen/NotFoundErrorAlertFullScreen/InvalidStatePageError';
+
+/**
+ * QueryString의 validation의 기준이 되는 객체에요.
+ *
+ * categories: string일 때 string[]로 만들어요.
+ * playTime: string일 때 number로 만들어요. 결과가 NaN이면 실패해요.
+ * noUnknown: 정의되지 않은 프로퍼티를 금지해요
+ * strict: 실패 시 빈 객체가 아닌 throw를 하게 해요.
+ */
+const querySchema = object({
+  difficulty: string(),
+  categories: mixed<string[]>().transform(value =>
+    value instanceof Array ? value : [value],
+  ),
+  playTime: mixed<number>().transform(value => parseInt(value, 10)),
+  searchKeyword: string(),
+})
+  .noUnknown()
+  .strict();
+
+/**
+ * queryString을 파싱하고 valid 하지 않으면 InvalidStatePageError 예외를 발생시켜요.
+ *
+ * 정상인 경우 값을 반환해요.
+ */
+export const useBoardGameListQueryParams = () => {
+  const [searchParams] = useSearchParams();
+  const queryObject = qs.parse(searchParams.toString());
+
+  let options;
+  try {
+    options = querySchema.validateSync(queryObject);
+  } catch {
+    throw new InvalidStatePageError();
+  }
+
+  return options;
+};

--- a/src/pages/BoardGameList/index.tsx
+++ b/src/pages/BoardGameList/index.tsx
@@ -19,9 +19,11 @@ export const BoardGameListPage = () => {
         </TabBar.Right>
       </TabBar.Container>
       <BoardGameListOptionFilterBar />
-      <Suspense fallback={<SpinnerFullScreen />}>
-        <BoardGameList />
-      </Suspense>
+      <div className='grow overflow-y-auto'>
+        <Suspense fallback={<SpinnerFullScreen />}>
+          <BoardGameList />
+        </Suspense>
+      </div>
       <GNB />
     </div>
   );

--- a/src/pages/BoardGameList/index.tsx
+++ b/src/pages/BoardGameList/index.tsx
@@ -1,0 +1,30 @@
+import { Suspense } from 'react';
+
+import { GNB } from '@/components/GNB';
+import SpinnerFullScreen from '@/components/Spinner/SpinnerFullScreen';
+import TabBar from '@/components/TabBar';
+
+import BoardGameList from './components/BoardGameList';
+import BoardGameListOptionFilterBar from './components/BoardGameListOptionFilterBar';
+
+export const BoardGameListPage = () => {
+  return (
+    <div className='flex h-full flex-col'>
+      <TabBar.Container>
+        <TabBar.Left>
+          <TabBar.Title>게임 정보</TabBar.Title>
+        </TabBar.Left>
+        <TabBar.Right>
+          <TabBar.SearchButton />
+        </TabBar.Right>
+      </TabBar.Container>
+      <BoardGameListOptionFilterBar />
+      <Suspense fallback={<SpinnerFullScreen />}>
+        <BoardGameList />
+      </Suspense>
+      <GNB />
+    </div>
+  );
+};
+
+export default BoardGameListPage;

--- a/src/stories/pages/BoardGameListPage.stories.tsx
+++ b/src/stories/pages/BoardGameListPage.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { reactRouterParameters } from 'storybook-addon-react-router-v6';
+
+import { BOARD_GAMES_PAGE_URL } from '@/constants/pageRoutes';
+import boardGameListMocks from '@/mocks/boardGameList';
+import BoardGameListPage from '@/pages/BoardGameList';
+import { CommonPageLayoutDecorator } from '@/stories/CommonPageLayoutDecorator';
+
+const meta: Meta<typeof BoardGameListPage> = {
+  title: 'pages/BoardGameListPage',
+  tags: ['autodocs'],
+  component: BoardGameListPage,
+  decorators: [CommonPageLayoutDecorator],
+  parameters: {
+    msw: {
+      handlers: [...boardGameListMocks],
+    },
+    reactRouter: reactRouterParameters({
+      routing: {
+        useStoryElement: true,
+        path: BOARD_GAMES_PAGE_URL,
+      },
+    }),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof BoardGameListPage>;
+
+export const DefaultTemplate: Story = {};


### PR DESCRIPTION
resolves #138

## 🤷‍♂️ Description

- [x] 옵션필터바 구현: 난이도, 플레이시간, 카테고리
- [x] 목록 아이템 퍼블리싱
- [x] queryString validation
- [x] Story 추가

#### 미구현 사항

- [x] 무한 스크롤 구현 --> offset, limit이 API 반영되면 적용할게요~!
- [ ] 옵션필터바 - 인원수 --> API에 없어서 못 썼어요~!
- [ ] 검색 창 --> API는 되는데 검색창 UI가 없어서 못 했어요~!

### 추가 사항

- [x] ListItem의 너비 문제가 발생해 '난이도'를 아래로 내렸습니다!

## 📷 Screenshots

<img src="https://github.com/BoardSignal/Team-CivilWar-BoardSignal-FE/assets/28754907/0939326b-e00d-453d-9298-b1711e5f27ef" width=300 />

<img src="https://github.com/BoardSignal/Team-CivilWar-BoardSignal-FE/assets/28754907/339261fd-7fc7-4477-b3cb-35ea67d44d50" width=300 />


## 📒 Remarks

- 옵션필터바에서 option의 value와 text를 분리할 수 있게 제공해줘야 `분`을 표시할 수 있을 것 같아요.
- 시간의 경우 범위 조건 검색이 좋을 것 같아요.
- `Button`을 ListItem 혹은 full page 형태로 쓸 때의 variant를 만들면 좀 편할 것 같아요. (좌측 정렬, radius 제거, h-fit 등)
