### PR TITLE
[#172] Fix: 트랜지션, 다크모드, 공통 오류 핸들링 관련 버그 수정

### DIFF
--- a/src/components/GatheringList/index.tsx
+++ b/src/components/GatheringList/index.tsx
@@ -23,7 +23,7 @@ interface GatheringListProps {
 
 const GatheringList = ({ gatherings }: GatheringListProps) => {
   return (
-    <section className='grow overflow-y-auto'>
+    <section className='grow overflow-y-auto overflow-x-hidden'>
       <ul>
         {gatherings.map(gathering => (
           <GatheringListItem key={gathering.id} gathering={gathering} />

--- a/src/components/LocationSelect/LocationListModal.tsx
+++ b/src/components/LocationSelect/LocationListModal.tsx
@@ -47,7 +47,7 @@ const LocationListModal = ({ onClose, onSelect }: LocationListModalProps) => {
             placeholder='장소를 검색하세요...'
           />
         </div>
-        <div className='grow overflow-y-auto'>
+        <div className='grow overflow-y-auto overflow-x-hidden'>
           {searchWord && (
             <ApiErrorBoundary>
               <Suspense fallback={<SpinnerFullScreen />}>

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -43,11 +43,11 @@ const Modal = ({
 
   return (
     <LayoutRootPortal>
-      <div className='backdrop absolute inset-0 z-[100] flex h-full items-center justify-center'>
+      <div className='backdrop absolute inset-0 h-full w-full opacity-70' />
+      <div className='absolute inset-0 z-[100] flex h-full items-center justify-center'>
         <div className='flex w-[66%] flex-col items-center rounded-lg bg-gray-bg-base p-8'>
           <label className={modalTitleCSS({ variant })}>{title}</label>
           <p className='text-m text-gray-accent2'>{children}</p>
-
           {variant === 'primary' && (
             <Button variant='primary' onClick={onClose} className='mt-8'>
               {buttonChildren}

--- a/src/components/SubwaySelect/SubwayLineList.tsx
+++ b/src/components/SubwaySelect/SubwayLineList.tsx
@@ -15,7 +15,7 @@ const SubwayLineList = ({
   selectedLine,
 }: SubwayLineListProps) => {
   return (
-    <div className='scroll-none h-full overflow-y-auto border-r border-gray-accent7'>
+    <div className='scroll-none h-full overflow-y-auto overflow-x-hidden border-r border-gray-accent7'>
       {lines.map(({ name, color }) => (
         <Button
           key={name}

--- a/src/components/SubwaySelect/SubwayListModal.tsx
+++ b/src/components/SubwaySelect/SubwayListModal.tsx
@@ -49,7 +49,7 @@ const SubwayListModal = ({ onClose, onSelect }: SubwayListModalProps) => {
           states={states}
           selectedState={selectedState}
         />
-        <div className='scroll-none flex grow overflow-y-auto'>
+        <div className='scroll-none flex grow overflow-y-auto overflow-x-hidden'>
           <SubwayLineList
             onSelect={handleLineSelect}
             selectedLine={selectedLine}

--- a/src/components/SubwaySelect/SubwayStationList.tsx
+++ b/src/components/SubwaySelect/SubwayStationList.tsx
@@ -7,7 +7,7 @@ interface SubwayStationListProps {
 
 const SubwayStationList = ({ onSelect, stations }: SubwayStationListProps) => {
   return (
-    <div className='scroll-none h-full grow overflow-y-auto'>
+    <div className='scroll-none h-full grow overflow-y-auto overflow-x-hidden'>
       {stations.map(name => {
         const handleClick = () => {
           onSelect(name);

--- a/src/components/UserProfile/UserSignalTemperature.tsx
+++ b/src/components/UserProfile/UserSignalTemperature.tsx
@@ -12,7 +12,7 @@ const UserSignalTemperature = ({ temperature }: UserSignalTemperatureProps) => {
   const { text, background } = getColorByTemperature(temperature);
 
   return (
-    <div className='flex flex-col items-end gap-1'>
+    <div className='relative flex flex-col items-end gap-1'>
       <div className='flex'>
         <div className='flex flex-col'>
           <span
@@ -38,8 +38,8 @@ const UserSignalTemperature = ({ temperature }: UserSignalTemperatureProps) => {
             시그널온도
           </span>
         </PopoverTrigger>
-        <PopoverContent className='relative right-[60px] z-20'>
-          <p className='tooltip before:left-[85%]'>
+        <PopoverContent className='absolute -right-8 z-20'>
+          <p className='tooltip text-gray-bg-base before:left-[85%]'>
             {SIGNAL_TEMPERATURE_EXPLAIN_MESSAGE}
           </p>
         </PopoverContent>

--- a/src/pages/BoardGameDetail/index.tsx
+++ b/src/pages/BoardGameDetail/index.tsx
@@ -32,7 +32,7 @@ const BoardGameDetailPage = () => {
           <TabBar.Title>{name}</TabBar.Title>
         </TabBar.Left>
       </TabBar.Container>
-      <div className='flex h-full grow flex-col overflow-y-auto'>
+      <div className='flex h-full grow flex-col overflow-y-auto overflow-x-hidden'>
         <img src={imageUrl} className='h-60' alt={name} />
         <div className='flex flex-col items-center gap-3 border-b border-gray-accent7 py-5'>
           <GameSummary name={name} categories={categories} />

--- a/src/pages/BoardGameList/index.tsx
+++ b/src/pages/BoardGameList/index.tsx
@@ -19,7 +19,7 @@ export const BoardGameListPage = () => {
         </TabBar.Right>
       </TabBar.Container>
       <BoardGameListOptionFilterBar />
-      <div className='grow overflow-y-auto'>
+      <div className='grow overflow-y-auto overflow-x-hidden'>
         <Suspense fallback={<SpinnerFullScreen />}>
           <BoardGameList />
         </Suspense>

--- a/src/pages/ChatRoom/components/ChatContainer/index.tsx
+++ b/src/pages/ChatRoom/components/ChatContainer/index.tsx
@@ -22,7 +22,7 @@ const ChatContainer = ({ gatheringId }: ChatContainerProps) => {
     <ReverseInfiniteScrollAutoFetch
       hasNextPage={hasNextPage}
       fetchNextPage={fetchNextPage}
-      className='flex grow flex-col overflow-y-auto p-4'
+      className='flex grow flex-col overflow-y-auto overflow-x-hidden p-4'
       data={messages}
     >
       {messages.map((message, index) => {

--- a/src/pages/ChatRoomList/components/ChatRoomList/index.tsx
+++ b/src/pages/ChatRoomList/components/ChatRoomList/index.tsx
@@ -16,7 +16,7 @@ const ChatRoomList = () => {
       fetchNextPage={fetchNextPage}
       fetchStatus={isFetchingNextPage ? 'fetching' : 'idle'}
       loaderElement={<SpinnerListBottom />}
-      className='grow overflow-y-auto'
+      className='grow overflow-y-auto overflow-x-hidden'
     >
       <ul>
         {chatRooms?.map(chatRoom => (

--- a/src/pages/EndGames/components/EndGameList/index.tsx
+++ b/src/pages/EndGames/components/EndGameList/index.tsx
@@ -23,7 +23,7 @@ const EndGameList = ({ userId }: EndGameListProps) => {
       fetchNextPage={fetchNextPage}
       fetchStatus={isFetchingNextPage ? 'fetching' : 'idle'}
       loaderElement={<SpinnerListBottom />}
-      className='grow overflow-y-auto'
+      className='grow overflow-y-auto overflow-x-hidden'
     >
       <ul>
         {endGames.map(endGame => {

--- a/src/pages/GatheringCreate/components/GatheringCreateForm/index.tsx
+++ b/src/pages/GatheringCreate/components/GatheringCreateForm/index.tsx
@@ -64,7 +64,7 @@ const GatheringCreateForm = ({ onCreate }: GatheringCreateFormProps) => {
       onSubmit={handleSubmit(onSubmitGathering)}
       className='flex grow flex-col overflow-y-hidden'
     >
-      <div className='overflow-y-auto'>
+      <div className='overflow-y-auto overflow-x-hidden'>
         <Controller
           name='thumbnailImage'
           control={control}

--- a/src/pages/GatheringDetail/components/GatheringIntroduce/index.tsx
+++ b/src/pages/GatheringDetail/components/GatheringIntroduce/index.tsx
@@ -33,7 +33,7 @@ const GatheringIntroduce = ({
     gatheringIntroduce;
 
   return (
-    <div className='flex h-full grow flex-col overflow-y-auto'>
+    <div className='flex h-full grow flex-col overflow-y-auto overflow-x-hidden'>
       <img
         src={imageUrl ?? DEFAULT_IMAGE_URL}
         alt='모임 이미지'

--- a/src/pages/GatheringDetail/components/GatheringParticipants/index.tsx
+++ b/src/pages/GatheringDetail/components/GatheringParticipants/index.tsx
@@ -59,7 +59,7 @@ const GatheringParticipants = ({
 
   return (
     <>
-      <section className='flex h-full grow flex-col overflow-y-auto'>
+      <section className='flex h-full grow flex-col overflow-y-auto overflow-x-hidden'>
         <ul>
           {participants.map(participant => {
             const handleKickParticipant = () => handleKick(participant.userId);

--- a/src/pages/GatheringFix/index.tsx
+++ b/src/pages/GatheringFix/index.tsx
@@ -7,11 +7,14 @@ import TabBar from '@/components/TabBar';
 import { SUCCESS_FIX_GATHERING_MODAL_MESSAGE } from '@/constants/messages/modal';
 import { GATHERINGS_PAGE_URL } from '@/constants/pageRoutes';
 
+import useBlockNonParticipant from '../GatheringUnfix/hooks/useBlockNonParticipant';
 import GatheringFixForm from './GatheringFixForm';
 
 const GatheringFixPage = () => {
-  const [isModalOpen, setIsModalOpen] = useState(false);
   const { gatheringId } = useParams() as { gatheringId: string };
+  useBlockNonParticipant(gatheringId);
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const navigate = useNavigate();
 
   const handleOpenModal = () => {

--- a/src/pages/GatheringList/components/GatheringList/index.tsx
+++ b/src/pages/GatheringList/components/GatheringList/index.tsx
@@ -60,7 +60,7 @@ const GatheringList = () => {
       fetchNextPage={fetchNextPage}
       fetchStatus={isFetchingNextPage ? 'fetching' : 'idle'}
       loaderElement={<SpinnerListBottom />}
-      className='grow overflow-y-auto'
+      className='grow overflow-y-auto overflow-x-hidden'
     >
       <ul>
         {gatherings.map(gathering => (

--- a/src/pages/GatheringUnfix/hooks/useBlockIfNotFixed.ts
+++ b/src/pages/GatheringUnfix/hooks/useBlockIfNotFixed.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+import { useGetGatheringDetailApi } from '@/apis/gatheringDetail';
+import InvalidStatePageError from '@/components/ErrorAlertFullScreen/NotFoundErrorAlertFullScreen/InvalidStatePageError';
+
+const useBlockIfNotFixed = (gatheringId: string) => {
+  const {
+    gathering: { isFix },
+  } = useGetGatheringDetailApi(gatheringId);
+
+  useEffect(() => {
+    if (isFix === '미확정') {
+      throw new InvalidStatePageError();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+};
+
+export default useBlockIfNotFixed;

--- a/src/pages/GatheringUnfix/hooks/useBlockNonParticipant.ts
+++ b/src/pages/GatheringUnfix/hooks/useBlockNonParticipant.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+import { useGetGatheringDetailApi } from '@/apis/gatheringDetail';
+import InvalidStatePageError from '@/components/ErrorAlertFullScreen/NotFoundErrorAlertFullScreen/InvalidStatePageError';
+import useGetLoggedInUserId from '@/hooks/useGetLoggedInUserId';
+
+const useBlockNonParticipant = (gatheringId: string) => {
+  const currentUserId = useGetLoggedInUserId();
+  const {
+    gathering: { participantResponse: participants },
+  } = useGetGatheringDetailApi(gatheringId);
+
+  useEffect(() => {
+    const isParticipant = participants.some(
+      ({ userId }) => currentUserId === userId,
+    );
+
+    if (!isParticipant) {
+      throw new InvalidStatePageError();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+};
+
+export default useBlockNonParticipant;

--- a/src/pages/GatheringUnfix/index.tsx
+++ b/src/pages/GatheringUnfix/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { useGetGatheringDetailApi } from '@/apis/gatheringDetail';
+import InvalidStatePageError from '@/components/ErrorAlertFullScreen/NotFoundErrorAlertFullScreen/InvalidStatePageError';
 import Modal from '@/components/Modal';
 import TabBar from '@/components/TabBar';
 import Alert from '@/components/alert';
@@ -39,7 +40,7 @@ const GatheringUnfixPage = () => {
     );
 
     if (isFix === '미확정' || !isParticipant) {
-      throw new Error('Inaccessible page');
+      throw new InvalidStatePageError();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/pages/GatheringUnfix/index.tsx
+++ b/src/pages/GatheringUnfix/index.tsx
@@ -1,31 +1,28 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { useGetGatheringDetailApi } from '@/apis/gatheringDetail';
-import InvalidStatePageError from '@/components/ErrorAlertFullScreen/NotFoundErrorAlertFullScreen/InvalidStatePageError';
 import Modal from '@/components/Modal';
 import TabBar from '@/components/TabBar';
 import Alert from '@/components/alert';
 import { UNFIX_GATHERING_ALERT_MESSAGE } from '@/constants/messages/alert';
 import { SUCCESS_UNFIX_GATHERING_MODAL_MESSAGE } from '@/constants/messages/modal';
 import { GATHERINGS_PAGE_URL } from '@/constants/pageRoutes';
-import useGetLoggedInUserId from '@/hooks/useGetLoggedInUserId';
 
 import GatheringUnfixForm from './components/GatheringUnfixForm';
+import useBlockIfNotFixed from './hooks/useBlockIfNotFixed';
+import useBlockNonParticipant from './hooks/useBlockNonParticipant';
 
 const GatheringUnfixPage = () => {
   const { gatheringId } = useParams() as {
     gatheringId: string;
   };
 
+  useBlockNonParticipant(gatheringId);
+  useBlockIfNotFixed(gatheringId);
+
   const navigate = useNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
-
-  const currentUserId = useGetLoggedInUserId();
-  const {
-    gathering: { isFix, participantResponse: participants },
-  } = useGetGatheringDetailApi(gatheringId);
 
   const handleOpenModal = () => setIsModalOpen(true);
 
@@ -33,17 +30,6 @@ const GatheringUnfixPage = () => {
     setIsModalOpen(false);
     navigate(`${GATHERINGS_PAGE_URL}/${gatheringId}`);
   };
-
-  useEffect(() => {
-    const isParticipant = participants.some(
-      ({ userId }) => currentUserId === userId,
-    );
-
-    if (isFix === '미확정' || !isParticipant) {
-      throw new InvalidStatePageError();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <div className='flex h-full flex-col'>

--- a/src/pages/NotificationList/index.tsx
+++ b/src/pages/NotificationList/index.tsx
@@ -13,7 +13,7 @@ const NotificationListPage = () => {
       <TabBar.Container>
         <TabBar.Title>알림</TabBar.Title>
       </TabBar.Container>
-      <div className='grow overflow-y-auto'>
+      <div className='grow overflow-y-auto overflow-x-hidden'>
         <ApiErrorBoundary>
           <Suspense fallback={<SpinnerFullScreen />}>
             <NotificationList />

--- a/src/pages/Profile/components/SignalTemperature/index.tsx
+++ b/src/pages/Profile/components/SignalTemperature/index.tsx
@@ -21,8 +21,10 @@ const SignalTemperature = ({ value }: TemperatureProps) => {
             <Icon id='information-line' size={16}></Icon>
           </span>
         </PopoverTrigger>
-        <PopoverContent className='relative z-20 ml-[60px]'>
-          <p className='tooltip'>{SIGNAL_TEMPERATURE_EXPLAIN_MESSAGE}</p>
+        <PopoverContent className='absolute -left-10 z-20'>
+          <p className='tooltip text-gray-bg-base'>
+            {SIGNAL_TEMPERATURE_EXPLAIN_MESSAGE}
+          </p>
         </PopoverContent>
       </Popover>
       <div className='flex flex-col gap-1'>

--- a/src/pages/Profile/index.tsx
+++ b/src/pages/Profile/index.tsx
@@ -42,7 +42,7 @@ const ProfilePage = () => {
           <TabBar.SettingsButton />
         </TabBar.Right>
       </TabBar.Container>
-      <div className='grow overflow-y-auto'>
+      <div className='grow overflow-y-auto overflow-x-hidden'>
         <PersonalInfo personalInfo={personalInfo} />
         {isProfileManager && <EditProfileButton userId={userId} />}
         <div className='flex flex-col gap-2 border-b border-gray-accent7 p-4'>

--- a/src/pages/ProfileEdit/components/ProfileEditForm/index.tsx
+++ b/src/pages/ProfileEdit/components/ProfileEditForm/index.tsx
@@ -40,7 +40,7 @@ const ProfileEditForm = ({ onProfileEdit }: ProfileEditFormProps) => {
       onSubmit={handleSubmit(onSubmitProfileEdit)}
       className='flex grow flex-col overflow-y-hidden'
     >
-      <div className='grow overflow-y-auto'>
+      <div className='grow overflow-y-auto overflow-x-hidden'>
         <Controller
           name='profileImageUrl'
           control={control}

--- a/src/pages/Register/components/RegisterForm/index.tsx
+++ b/src/pages/Register/components/RegisterForm/index.tsx
@@ -43,7 +43,7 @@ const RegisterForm = ({ onRegister }: RegisterFormProps) => {
       onSubmit={handleSubmit(onSubmitResister)}
       className='flex grow flex-col overflow-y-hidden'
     >
-      <div className='grow overflow-y-auto'>
+      <div className='grow overflow-y-auto overflow-x-hidden'>
         <Controller
           name='profileImageUrl'
           control={control}

--- a/src/pages/ReviewCreate/components/ReviewForm/index.tsx
+++ b/src/pages/ReviewCreate/components/ReviewForm/index.tsx
@@ -83,7 +83,7 @@ const ReviewForm = ({
 
   return (
     <div className='flex h-full flex-col overflow-hidden'>
-      <div className='flex-grow overflow-y-auto'>
+      <div className='flex-grow overflow-y-auto overflow-x-hidden'>
         {reviewList.map(({ revieweeId, reviewContent }) => {
           const userProfile = participantsInfos.find(
             info => info.userId === revieweeId,
@@ -94,7 +94,7 @@ const ReviewForm = ({
               key={revieweeId}
               className='flex grow flex-col overflow-hidden'
             >
-              <div className='bt-gray-accent7 grow gap-2 overflow-y-auto border-t pb-2'>
+              <div className='bt-gray-accent7 grow gap-2 overflow-y-auto overflow-x-hidden border-t pb-2'>
                 {userProfile && (
                   <UserProfile
                     userProfile={{


### PR DESCRIPTION
resolves #172

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

### 요구 사항

- [x] 화면 전환 시 GNB 바로 위에 x축 스크롤바가 잠시 생겼다가 사라져요 -> overflow-x-hidden 추가
- [x] Toast, 시그널 온도 Tooltip 글자가 안 보여요 -> text-gray-bg-base 추가
- [x] 모달 배경이 투명하지 않아요 -> div에 opacity 추가
- [x] 확정 취소 후 뒤로가기 버튼을 누르면 확정 취소 페이지로 가는데, 오류가 뜨면서 갇혀버려요 -> Error 객체를 던지는 것에서 InvalidPageStateError를 던지는 것으로 변경 (`useBlockNonParticipant`, `useBlockIfNotFixed` 훅 추가)
- [x] 확정 취소 사유 입력 페이지에 접근할 수 없는 사용자가 접근한다면 404 페이지로 이동해야해요

### 추가로 발견/해결한 버그
- [x] Toast, 시그널 온도 Tooltip의 포지션 문제 -> 화면 넘김 버그 -> 반응형 대응 완료
- [x] `모임 확정` 페이지에는 url 입력 시 아무나 들어갈 수 있어요

### 새로 발견한 버그 (미해결)
