### PR TITLE
[#178] Fix: 보드게임 목록 조회 필터링 조건 버그 수정 

### DIFF
--- a/src/apis/boardGameList.ts
+++ b/src/apis/boardGameList.ts
@@ -42,7 +42,7 @@ const getBoardGameList = (
   api.get<BoardGameListResponse>({
     url: BOARD_GAMES_PAGE_URL,
     params: {
-      options,
+      ...options,
       size,
       page,
     },


### PR DESCRIPTION
resolves #178

## 🤷‍♂️ Description

- [x] 필터링 querystring을 잘못 보내고 있는 버그를 수정해요