### PR TITLE
[#180] Fix: Toast 라이트테마 텍스트 색상, 옵션필터바 key

### DIFF
--- a/src/components/OptionFilterBar/index.tsx
+++ b/src/components/OptionFilterBar/index.tsx
@@ -45,7 +45,7 @@ const OptionFilterBar = ({ options, resetUrl = '/' }: OptionFilterBarProps) => {
         </Link>
         {options.map(option => {
           if (option.items.length === 0) {
-            return <OptionSubwaySelect option={option} />;
+            return <OptionSubwaySelect key={option.name} option={option} />;
           }
 
           return option.items.length === 1 ? (

--- a/src/utils/showToast.tsx
+++ b/src/utils/showToast.tsx
@@ -12,7 +12,7 @@ import Icon from '@/components/Icon';
 export const showErrorToast = (message: string) => {
   toast.error(message, {
     // toast 자체의 style이 className의 스타일을 덮어써서 important를 적용해요
-    className: '!bg-gray-accent1 dark:!text-gray-bg-base !text-sm',
+    className: '!bg-gray-accent1 !text-gray-bg-base !text-sm',
     icon: <Icon id='error-warning-fill' className='size-4 text-red-500' />,
   });
 };


### PR DESCRIPTION
resolves #180

## 🤷‍♂️ Description

- [x] Toast 라이트테마 텍스트 색상 미적용 문제 해결 -> `dark` prefix 제거
- [x] 옵션필터바에서 SubwaySelect 사용시 key가 없어 경고가 뜨는 문제 해결 -> key 추가