### PR TITLE
[#188] Fix: 뒤로가기 제어

### DIFF
--- a/src/components/UserProfile/index.tsx
+++ b/src/components/UserProfile/index.tsx
@@ -67,7 +67,7 @@ const UserProfile = ({
     queryClient.invalidateQueries({
       queryKey: [GATHERING_DETAIL_QUERY_KEY, gatheringId],
     });
-    navigate(`${GATHERINGS_PAGE_URL}/${gatheringId}/0`);
+    navigate(`${GATHERINGS_PAGE_URL}/${gatheringId}/0`, { replace: true });
   };
 
   const handleKickParticipant = () => {

--- a/src/pages/CreateBoardGameTip/index.tsx
+++ b/src/pages/CreateBoardGameTip/index.tsx
@@ -20,7 +20,7 @@ const CreateBoardGameTipPage = () => {
 
   const handleCloseModal = () => {
     setIsModalOpen(false);
-    navigate(`${BOARD_GAMES_PAGE_URL}/${boardGameId}`);
+    navigate(`${BOARD_GAMES_PAGE_URL}/${boardGameId}`, { replace: true });
   };
 
   const handleOpenModal = () => {

--- a/src/pages/GatheringCreate/index.tsx
+++ b/src/pages/GatheringCreate/index.tsx
@@ -23,7 +23,9 @@ const GatheringCreatePage = () => {
 
   const handleCloseModal = () => {
     setIsModalOpen(false);
-    navigate(`${GATHERINGS_PAGE_URL}/${createdGatheringId}/0`);
+    navigate(`${GATHERINGS_PAGE_URL}/${createdGatheringId}/0`, {
+      replace: true,
+    });
   };
 
   const handleCreateGathering = (gatheringId: number) => {

--- a/src/pages/GatheringDetail/components/GatheringButton/index.tsx
+++ b/src/pages/GatheringDetail/components/GatheringButton/index.tsx
@@ -118,7 +118,7 @@ const DeleteGatheringButton = ({ gatheringId }: GatheringIdProps) => {
 
   const handleCloseIsSuccessModal = () => {
     setIsSuccessModalOpen(false);
-    navigate('/');
+    navigate('/', { replace: true });
   };
 
   const handleOpenIsSuccessModal = () => {

--- a/src/pages/GatheringDetail/components/TabMenu/index.tsx
+++ b/src/pages/GatheringDetail/components/TabMenu/index.tsx
@@ -25,7 +25,9 @@ const TabMenu = ({ tabs }: TabMenuProps) => {
             'text-gray-accent4': tabIndex !== String(index),
           })}
           onClick={() =>
-            navigate(`${GATHERINGS_PAGE_URL}/${gatheringId}/${index}`)
+            navigate(`${GATHERINGS_PAGE_URL}/${gatheringId}/${index}`, {
+              replace: true,
+            })
           }
         >
           {tab}

--- a/src/pages/GatheringDetail/index.tsx
+++ b/src/pages/GatheringDetail/index.tsx
@@ -35,11 +35,15 @@ const GatheringDetailPage = () => {
     ? participantResponse.some(({ userId }) => userId === data.id)
     : false;
 
+  const goToGatheringListPage = () => {
+    navigate('/');
+  };
+
   return (
     <div className='flex h-full flex-col'>
       <TabBar.Container>
         <TabBar.Left>
-          <TabBar.GoBackButton />
+          <TabBar.GoBackButton onClick={goToGatheringListPage} />
         </TabBar.Left>
         <TabBar.Right>
           {isParticipation && (

--- a/src/pages/GatheringFix/index.tsx
+++ b/src/pages/GatheringFix/index.tsx
@@ -23,7 +23,7 @@ const GatheringFixPage = () => {
 
   const handleCloseModal = () => {
     setIsModalOpen(false);
-    navigate(`${GATHERINGS_PAGE_URL}/${gatheringId}/0`);
+    navigate(`${GATHERINGS_PAGE_URL}/${gatheringId}/0`, { replace: true });
   };
 
   return (

--- a/src/pages/GatheringUnfix/index.tsx
+++ b/src/pages/GatheringUnfix/index.tsx
@@ -28,7 +28,7 @@ const GatheringUnfixPage = () => {
 
   const handleCloseModal = () => {
     setIsModalOpen(false);
-    navigate(`${GATHERINGS_PAGE_URL}/${gatheringId}/0`);
+    navigate(`${GATHERINGS_PAGE_URL}/${gatheringId}/0`, { replace: true });
   };
 
   return (

--- a/src/pages/Profile/hooks/useLogout.ts
+++ b/src/pages/Profile/hooks/useLogout.ts
@@ -11,7 +11,7 @@ export const useLogout = () => {
     logoutApi: async () => {
       await api();
       localStorage.removeItem(STORAGE_KEY_ACCESS_TOKEN);
-      navigate('/');
+      navigate('/', { replace: true });
     },
   };
 };

--- a/src/pages/ProfileEdit/index.tsx
+++ b/src/pages/ProfileEdit/index.tsx
@@ -20,7 +20,7 @@ const ProfileEdit = () => {
 
   const handleCloseModal = () => {
     setIsModalOpen(false);
-    navigate(`/users/${userId}`);
+    navigate(`/users/${userId}`, { replace: true });
   };
 
   const handleProfileEdit = (userId: number) => {

--- a/src/pages/Register/index.tsx
+++ b/src/pages/Register/index.tsx
@@ -19,7 +19,7 @@ const RegisterPage = () => {
   useEffect(() => {
     if (isJoined) {
       showErrorToast(IS_SIGN_UP_USER_MESSAGE);
-      navigate('/');
+      navigate('/', { replace: true });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -30,7 +30,7 @@ const RegisterPage = () => {
 
   const handleCloseModal = () => {
     setIsModalOpen(false);
-    navigate('/');
+    navigate('/', { replace: true });
   };
 
   return (

--- a/src/pages/ReviewCreate/index.tsx
+++ b/src/pages/ReviewCreate/index.tsx
@@ -23,7 +23,7 @@ const ReviewCreate = () => {
 
   const handleCloseModal = () => {
     setIsModalOpen(false);
-    navigate(ROOMS_MY_END_GAMES_API_URL);
+    navigate(ROOMS_MY_END_GAMES_API_URL, { replace: true });
   };
 
   const handleReviewCreate = () => {


### PR DESCRIPTION
## 💬 Issue Number

> closes #188

## 🤷‍♂️ Description
### replace 옵션 추가
아래 경우 경로 이동 시 `replace: true` 옵션을 추가해 페이지 이동 시 새로운 스택을 쌓지 않고 대체합니다.
- 모임 생성 후 모임 상세 페이지로 이동
- 모임 확정 후 모임 상세 페이지로 이동
- 모임 확정 취소 후 모임 상세 페이지로 이동
- 모임 삭제 후 메인 페이지로 이동
- 리뷰 작성 후 종료된 게임 목록 페이지로 이동
- 강퇴 후 모임 상세 페이지로 이동
- 보드게임 공략 작성 후 보드게임 상세 페이지로 이동
- 모임 상세 페이지 내 Tab 이동
- 로그아웃 후 메인 페이지로 이동
- 프로필 수정 후 프로필 페이지로 이동
- 회원가입 페이지에서 메인 페이지로 이동

### TabBar 뒤로가기
- 모임 상세 페이지 `TabBar` 뒤로가기 버튼 클릭 시 메인 페이지로 이동하도록 수정했습니다.

## 👻 Good Function
```javascript
import { useNavigate } from 'react-router-dom';

const navigate = useNavigate();

navigate(url, { replace: true };
```

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 📒 Remarks
이동 전에 풀 스크린 모달(지하철역, 장소 피커)을 사용하는 작성 페이지는 모달 사용 시 `pushState`를 하기 때문에 브라우저 뒤로가기 버튼을 누르면 다시 작성 페이지로 이동하게 됩니다. 이 문제는 추후에 해결해야 할 것 같습니다!
- 모임 생성, 모임 확정, 프로필 수정, 회원가입 페이지