### PR TITLE
[#193] Fix: 회원가입, 프로필 수정페이지 필드변경

### DIFF
--- a/src/pages/ProfileEdit/components/ProfileEditForm/formSchema.ts
+++ b/src/pages/ProfileEdit/components/ProfileEditForm/formSchema.ts
@@ -16,4 +16,6 @@ export const profileEditSchema = object({
     .max(10, `10${MAX_LENGTH_ERROR_MESSAGE}`),
   station: string().defined(),
   categories: array(string().defined()).required(),
+  gender: string().required(REQUIRED_ERROR_MESSAGE),
+  birth: string().required(REQUIRED_ERROR_MESSAGE),
 });

--- a/src/pages/ProfileEdit/components/ProfileEditForm/formSchema.ts
+++ b/src/pages/ProfileEdit/components/ProfileEditForm/formSchema.ts
@@ -16,6 +16,4 @@ export const profileEditSchema = object({
     .max(10, `10${MAX_LENGTH_ERROR_MESSAGE}`),
   station: string().defined(),
   categories: array(string().defined()).required(),
-  gender: string().required(REQUIRED_ERROR_MESSAGE),
-  birth: string().required(REQUIRED_ERROR_MESSAGE),
 });

--- a/src/pages/ProfileEdit/components/ProfileEditForm/index.tsx
+++ b/src/pages/ProfileEdit/components/ProfileEditForm/index.tsx
@@ -33,7 +33,7 @@ const ProfileEditForm = ({ onProfileEdit }: ProfileEditFormProps) => {
     nickname,
     station: `${subwayStation} (${subwayLine})`,
     categories,
-    birth: `${birth}`,
+    birth: String(birth),
     gender,
   };
 
@@ -54,7 +54,7 @@ const ProfileEditForm = ({ onProfileEdit }: ProfileEditFormProps) => {
   const onSubmitProfileEdit = (data: ProfileEditFormValue) => {
     const request = profileEditRequestMapper({
       ...data,
-      birth: `${birth}`,
+      birth: String(birth),
       gender,
     });
     editProfile(request);

--- a/src/pages/ProfileEdit/components/ProfileEditForm/index.tsx
+++ b/src/pages/ProfileEdit/components/ProfileEditForm/index.tsx
@@ -25,21 +25,16 @@ interface ProfileEditFormProps {
 
 const ProfileEditForm = ({ onProfileEdit }: ProfileEditFormProps) => {
   const editProfile = useProfileEdit(onProfileEdit);
-  const {
-    name,
-    birth,
-    gender,
-    nickname,
-    subwayStation,
-    subwayLine,
-    categories,
-  } = useGetLoggedInUserApi();
+  const { birth, gender, nickname, subwayStation, subwayLine, categories } =
+    useGetLoggedInUserApi();
 
   const profileEditDefaultValue = {
     profileImageUrl: new File([], ''),
     nickname,
     station: `${subwayStation} (${subwayLine})`,
     categories,
+    birth: String(birth),
+    gender,
   };
 
   const profileEditFormOptions = {
@@ -53,6 +48,7 @@ const ProfileEditForm = ({ onProfileEdit }: ProfileEditFormProps) => {
     handleSubmit,
     formState: { isValid, errors },
     control,
+    watch,
   } = useForm(profileEditFormOptions);
 
   const onSubmitProfileEdit = (data: ProfileEditFormValue) => {
@@ -76,19 +72,13 @@ const ProfileEditForm = ({ onProfileEdit }: ProfileEditFormProps) => {
           }}
         />
         <section className='flex flex-col gap-4 p-4'>
-          <Label title='이름'>
-            <TextInput
-              disabled={true}
-              value={name}
-              className='text-gray-accent3'
-            />
-          </Label>
           <div className='flex gap-4'>
             <Label title='출생년도'>
               <TextInput
                 disabled={true}
                 value={birth}
                 className='text-gray-accent3'
+                {...register('birth')}
               />
             </Label>
             <Label title='성별'>
@@ -96,13 +86,18 @@ const ProfileEditForm = ({ onProfileEdit }: ProfileEditFormProps) => {
                 disabled={true}
                 value={gender}
                 className='text-gray-accent3'
+                {...register('gender')}
               />
             </Label>
           </div>
-          <Label title='닉네임' isRequired>
+          <Label
+            maxLength={10}
+            title='닉네임'
+            isRequired
+            currentLength={watch('nickname')?.length}
+          >
             <TextInput
               variant={errors.nickname ? 'error' : 'default'}
-              maxLength={50}
               {...register('nickname')}
             />
             <FormErrorMessage message={errors.nickname?.message} />

--- a/src/pages/ProfileEdit/components/ProfileEditForm/index.tsx
+++ b/src/pages/ProfileEdit/components/ProfileEditForm/index.tsx
@@ -33,7 +33,7 @@ const ProfileEditForm = ({ onProfileEdit }: ProfileEditFormProps) => {
     nickname,
     station: `${subwayStation} (${subwayLine})`,
     categories,
-    birth: String(birth),
+    birth: `${birth}`,
     gender,
   };
 
@@ -52,7 +52,11 @@ const ProfileEditForm = ({ onProfileEdit }: ProfileEditFormProps) => {
   } = useForm(profileEditFormOptions);
 
   const onSubmitProfileEdit = (data: ProfileEditFormValue) => {
-    const request = profileEditRequestMapper(data);
+    const request = profileEditRequestMapper({
+      ...data,
+      birth: `${birth}`,
+      gender,
+    });
     editProfile(request);
   };
 
@@ -78,7 +82,6 @@ const ProfileEditForm = ({ onProfileEdit }: ProfileEditFormProps) => {
                 disabled={true}
                 value={birth}
                 className='text-gray-accent3'
-                {...register('birth')}
               />
             </Label>
             <Label title='성별'>
@@ -86,7 +89,6 @@ const ProfileEditForm = ({ onProfileEdit }: ProfileEditFormProps) => {
                 disabled={true}
                 value={gender}
                 className='text-gray-accent3'
-                {...register('gender')}
               />
             </Label>
           </div>

--- a/src/pages/ProfileEdit/components/ProfileEditForm/profileEditMapper.ts
+++ b/src/pages/ProfileEdit/components/ProfileEditForm/profileEditMapper.ts
@@ -6,13 +6,16 @@ import {
 export interface ProfileEditFormValue {
   profileImageUrl: File;
   nickname: string;
-  gender: string;
-  birth: string;
   station: string;
   categories: string[];
 }
 
-const ProfileEditRequestMapper = (data: ProfileEditFormValue) => {
+export interface ProfileFormValue extends ProfileEditFormValue {
+  gender: string;
+  birth: string;
+}
+
+const ProfileEditRequestMapper = (data: ProfileFormValue) => {
   const {
     nickname: nickName,
     birth,

--- a/src/pages/ProfileEdit/components/ProfileEditForm/profileEditMapper.ts
+++ b/src/pages/ProfileEdit/components/ProfileEditForm/profileEditMapper.ts
@@ -6,17 +6,28 @@ import {
 export interface ProfileEditFormValue {
   profileImageUrl: File;
   nickname: string;
+  gender: string;
+  birth: string;
   station: string;
   categories: string[];
 }
 
 const ProfileEditRequestMapper = (data: ProfileEditFormValue) => {
-  const { nickname: nickName, station, categories, profileImageUrl } = data;
+  const {
+    nickname: nickName,
+    birth,
+    gender,
+    station,
+    categories,
+    profileImageUrl,
+  } = data;
 
   return {
     profileImageUrl,
     userProfile: {
       nickName,
+      gender,
+      birth,
       line: extractLineFromSubwayName(station),
       station: extractStationFromSubwayName(station),
       categories,

--- a/src/pages/Register/components/RegisterForm/formSchema.ts
+++ b/src/pages/Register/components/RegisterForm/formSchema.ts
@@ -10,6 +10,8 @@ import {
 
 export const registerSchema = object({
   profileImageUrl: mixed<File>().required(),
+  birth: string().required(REQUIRED_ERROR_MESSAGE),
+  gender: string().required(REQUIRED_ERROR_MESSAGE),
   nickname: string()
     .required(REQUIRED_ERROR_MESSAGE)
     .trim()
@@ -23,6 +25,8 @@ export const registerSchema = object({
 
 export const registerDefaultValue = {
   profileImageUrl: new File([], ''),
+  birth: '',
+  gender: '',
   nickname: '',
   station: '',
   categories: [],

--- a/src/pages/Register/components/RegisterForm/index.tsx
+++ b/src/pages/Register/components/RegisterForm/index.tsx
@@ -1,11 +1,11 @@
 import { Controller, useForm } from 'react-hook-form';
 
-import { useGetLoggedInUserApi } from '@/apis/loggedInUser';
 import Button from '@/components/Button';
 import ChipSelect from '@/components/ChipSelect';
 import FormErrorMessage from '@/components/FormErrorMessage';
 import ImageUpload from '@/components/ImageUpload';
 import Label from '@/components/Label';
+import Select from '@/components/Select';
 import SubwaySelect from '@/components/SubwaySelect';
 import TextInput from '@/components/TextInput';
 import {
@@ -25,16 +25,23 @@ interface RegisterFormProps {
   onRegister: OnRegister;
 }
 
+const BIRTH_YEAR_OPTIONS = Array.from({ length: 30 }, (_, idx) =>
+  String(idx + 1980),
+);
+const BIRTH_YEAR_PLACEHOLDER = '출생년도선택';
+const GENDER_OPTIONS = ['남성', '여성'];
+const GENDER_PLACEHOLDER = '성별 선택';
+
 const RegisterForm = ({ onRegister }: RegisterFormProps) => {
   const {
     register,
     handleSubmit,
     formState: { errors, isValid },
     control,
+    watch,
   } = useForm(registerFormOptions);
 
   const registerUser = useRegister(onRegister);
-  const { name, birth, gender } = useGetLoggedInUserApi();
   const onSubmitResister = (data: RegisterFormValue) => {
     const request = registerRequestMapper(data);
     registerUser(request);
@@ -56,33 +63,38 @@ const RegisterForm = ({ onRegister }: RegisterFormProps) => {
           }}
         />
         <section className='flex flex-col gap-4 p-4'>
-          <Label title='이름'>
-            <TextInput
-              disabled={true}
-              value={name}
-              className='text-gray-accent3'
-            />
-          </Label>
-          <div className='flex gap-4'>
-            <Label title='출생년도'>
-              <TextInput
-                disabled={true}
-                value={birth}
-                className='text-gray-accent3'
-              />
-            </Label>
-            <Label title='성별'>
-              <TextInput
-                disabled={true}
-                value={gender}
-                className='text-gray-accent3'
-              />
-            </Label>
+          <div className='flex w-full gap-8'>
+            <div className='w-1/2'>
+              <Label title='출생년도' isRequired>
+                <Select
+                  options={BIRTH_YEAR_OPTIONS}
+                  placeholder={BIRTH_YEAR_PLACEHOLDER}
+                  variant={errors.birth ? 'error' : 'default'}
+                  {...register('birth')}
+                />
+                <FormErrorMessage message={errors.birth?.message} />
+              </Label>
+            </div>
+            <div className='w-2/5'>
+              <Label title='성별' isRequired>
+                <Select
+                  options={GENDER_OPTIONS}
+                  placeholder={GENDER_PLACEHOLDER}
+                  variant={errors.gender ? 'error' : 'default'}
+                  {...register('gender')}
+                />
+                <FormErrorMessage message={errors.gender?.message} />
+              </Label>
+            </div>
           </div>
-          <Label title='닉네임' isRequired>
+          <Label
+            title='닉네임'
+            isRequired
+            currentLength={watch('nickname')?.length}
+            maxLength={10}
+          >
             <TextInput
               variant={errors.nickname ? 'error' : 'default'}
-              maxLength={50}
               {...register('nickname')}
             />
             <FormErrorMessage message={errors.nickname?.message} />

--- a/src/pages/Register/components/RegisterForm/registerMapper.ts
+++ b/src/pages/Register/components/RegisterForm/registerMapper.ts
@@ -6,6 +6,8 @@ import {
 export interface RegisterFormValue {
   profileImageUrl: File;
   nickname: string;
+  birth: string;
+  gender: string;
   station: string;
   categories: string[];
   isAgreeTerms: boolean;
@@ -13,12 +15,21 @@ export interface RegisterFormValue {
 }
 
 const registerRequestMapper = (data: RegisterFormValue) => {
-  const { nickname: nickName, station, categories, profileImageUrl } = data;
+  const {
+    nickname: nickName,
+    birth,
+    gender,
+    station,
+    categories,
+    profileImageUrl,
+  } = data;
 
   return {
     profileImageUrl,
     userProfile: {
       nickName,
+      gender,
+      birth,
       line: extractLineFromSubwayName(station),
       station: extractStationFromSubwayName(station),
       categories,


### PR DESCRIPTION
## 💬 Issue Number

> closes #193

## 🤷‍♂️ Description
기존에 태어난 년도, 성별을 카카오에서 제공받았지만 실제 서비스에서 불가능했기에 사용자가 직접 입력하는 체계로 변환
기존의 실명은 사용하지 않고 닉네임 체계를 채택

> 작업 내용에 대한 설명

## 📷 Screenshots
<img width="455" alt="image" src="https://github.com/BoardSignal/Team-CivilWar-BoardSignal-FE/assets/102784200/ea1f5f5b-a7f0-4069-9749-5420f78abfd5">

> 작업 결과물

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항
* 디바운싱을 활용해서 작업을 하고싶었는데 생각대로 되지 않아 이후 새로운 작업으로 진행을 해봐야 할 것 같습니다. 