### PR TITLE
[#207] Fix: 모임 목록 페이지 Suspense추가, 레이아웃 수정

### DIFF
--- a/src/pages/GatheringList/index.tsx
+++ b/src/pages/GatheringList/index.tsx
@@ -1,5 +1,8 @@
+import { Suspense } from 'react';
+
 import tabBarLogo from '@/assets/tab-bar-logo.png';
 import { GNB } from '@/components/GNB';
+import SpinnerFullScreen from '@/components/Spinner/SpinnerFullScreen';
 import TabBar from '@/components/TabBar';
 import { GATHERING_SEARCH_PLACEHOLDER_MESSAGE } from '@/constants/messages/placeholder';
 import useInitializeFCM from '@/hooks/useInitializeFCM';
@@ -22,7 +25,11 @@ export const GatheringListPage = () => {
         </TabBar.Right>
       </TabBar.Container>
       <GatheringListOptionFilterBar />
-      <GatheringList />
+      <div className='grow overflow-y-auto overflow-x-hidden'>
+        <Suspense fallback={<SpinnerFullScreen />}>
+          <GatheringList />
+        </Suspense>
+      </div>
       <FloatingButton />
       <GNB />
     </div>


### PR DESCRIPTION
## 💬 Issue Number

> closes #207 

## 🤷‍♂️ Description
#192 에서 적용한 부분이 #198 머지 과정에서 제거되어 다시 수정합니다.
- 모임 목록 페이지에 `Suspense` 추가
- `GatheringList` 컴포넌트에 적용했던 레이아웃을 `GatheringListPage`에서 적용

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
