### PR TITLE
[#209] Refactor: 채팅 목록, 채팅방 페이지 개선

### DIFF
--- a/src/apis/chatRoomList.ts
+++ b/src/apis/chatRoomList.ts
@@ -3,13 +3,23 @@ import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import { ROOMS_CHATS_MY_GAMES_API_URL } from '@/constants/apiRoutes';
 import { CHAT_LIST_QUERY_KEY } from '@/constants/queryKey';
 
+import { MessageType } from './chatRoomMessages';
 import { api } from './core';
+
+export interface LastChatMessage {
+  roomId: number;
+  content: string;
+  messageType: MessageType;
+  createdAt: string;
+}
 
 export interface ChatRoom {
   id: number;
   title: string;
   imageUrl: string | null;
   headCount: number;
+  unreadChatCount: number;
+  lastChatMessage: LastChatMessage;
 }
 
 interface ChatRoomListResponse {

--- a/src/hooks/useSendChatMessage.ts
+++ b/src/hooks/useSendChatMessage.ts
@@ -73,7 +73,6 @@ const useSendChatMessage = ({
 
     client.current = new Client({
       webSocketFactory: () => socket,
-      debug: str => console.log(str),
       onConnect: () => subscribe(),
       onStompError: frame => {
         throw new Error(`Broker reported error: ${frame.headers.message}`);

--- a/src/pages/ChatRoom/components/ChatContainer/ChatAlert.tsx
+++ b/src/pages/ChatRoom/components/ChatContainer/ChatAlert.tsx
@@ -18,8 +18,9 @@ const ChatAlert = ({ message }: ChatAlertProps) => {
 
   return (
     <Alert variant={variant[type]} className='my-1.5'>
-      {type !== 'FIX' && type !== 'KICK' && nickname}
-      {content}
+      {type !== 'FIX' && type !== 'KICK' && nickname
+        ? nickname + content
+        : content.replace('님이', '참가자가')}
     </Alert>
   );
 };

--- a/src/pages/ChatRoom/components/ChatContainer/ChatBubble.tsx
+++ b/src/pages/ChatRoom/components/ChatContainer/ChatBubble.tsx
@@ -5,11 +5,11 @@ import { Link } from 'react-router-dom';
 import type { ChatMessage } from '@/apis/chatRoomMessages';
 import defaultProfileImage from '@/assets/default-profile-image.png';
 import { USERS_PAGE_URL } from '@/constants/pageRoutes';
-import useGetLoggedInUserId from '@/hooks/useGetLoggedInUserId';
 import { cn } from '@/utils/cn';
 import { formatToDate, formatToTime } from '@/utils/time';
 
 interface ChatBubbleProps {
+  currentUserId?: number;
   message: ChatMessage;
   isFirstMessage?: boolean;
 }
@@ -80,9 +80,12 @@ const OtherUserChatBubble = ({ message, isFirstMessage }: ChatBubbleProps) => (
   </div>
 );
 
-const ChatBubble = ({ message, isFirstMessage = false }: ChatBubbleProps) => {
+const ChatBubble = ({
+  currentUserId,
+  message,
+  isFirstMessage = false,
+}: ChatBubbleProps) => {
   const { userId } = message;
-  const currentUserId = useGetLoggedInUserId();
 
   return (
     <div>

--- a/src/pages/ChatRoom/components/ChatContainer/index.tsx
+++ b/src/pages/ChatRoom/components/ChatContainer/index.tsx
@@ -1,4 +1,6 @@
-import { useGetChatRoomMessagesApi } from '@/apis/chatRoomMessages';
+import { Fragment } from 'react';
+
+import { ChatMessage } from '@/apis/chatRoomMessages';
 import ReverseInfiniteScrollAutoFetch from '@/components/ReverseInfiniteScrollAutoFetch';
 import { EMPTY_CHAT_ROOM_MESSAGE } from '@/constants/messages/emptyScreens';
 import useGetLoggedInUserId from '@/hooks/useGetLoggedInUserId';
@@ -8,14 +10,16 @@ import ChatAlert from './ChatAlert';
 import ChatBubble, { ChatDate } from './ChatBubble';
 
 interface ChatContainerProps {
-  gatheringId: number;
+  messages: ChatMessage[];
+  hasNextPage: boolean;
+  fetchNextPage: () => void;
 }
 
-const ChatContainer = ({ gatheringId }: ChatContainerProps) => {
-  const { messages, hasNextPage, fetchNextPage } = useGetChatRoomMessagesApi(
-    gatheringId,
-    20,
-  );
+const ChatContainer = ({
+  messages,
+  hasNextPage,
+  fetchNextPage,
+}: ChatContainerProps) => {
   const currentUserId = useGetLoggedInUserId();
 
   if (messages.length === 0) {
@@ -38,16 +42,16 @@ const ChatContainer = ({ gatheringId }: ChatContainerProps) => {
 
         if (type !== 'CHAT') {
           return (
-            <>
+            <Fragment key={createdAt}>
               {index === messages.length - 1 ? (
-                <div key={createdAt}>
+                <div>
                   <ChatDate date={createdAt} />
                   <ChatAlert message={message} />
                 </div>
               ) : (
-                <ChatAlert key={createdAt} message={message} />
+                <ChatAlert message={message} />
               )}
-            </>
+            </Fragment>
           );
         }
 

--- a/src/pages/ChatRoom/components/ChatContainer/index.tsx
+++ b/src/pages/ChatRoom/components/ChatContainer/index.tsx
@@ -1,6 +1,7 @@
 import { useGetChatRoomMessagesApi } from '@/apis/chatRoomMessages';
 import ReverseInfiniteScrollAutoFetch from '@/components/ReverseInfiniteScrollAutoFetch';
 import { EMPTY_CHAT_ROOM_MESSAGE } from '@/constants/messages/emptyScreens';
+import useGetLoggedInUserId from '@/hooks/useGetLoggedInUserId';
 import { isDifferentDay } from '@/utils/time';
 
 import ChatAlert from './ChatAlert';
@@ -15,6 +16,7 @@ const ChatContainer = ({ gatheringId }: ChatContainerProps) => {
     gatheringId,
     20,
   );
+  const currentUserId = useGetLoggedInUserId();
 
   if (messages.length === 0) {
     return (
@@ -53,7 +55,11 @@ const ChatContainer = ({ gatheringId }: ChatContainerProps) => {
           return (
             <div key={createdAt}>
               <ChatDate date={createdAt} />
-              <ChatBubble isFirstMessage message={message} />
+              <ChatBubble
+                currentUserId={currentUserId}
+                isFirstMessage
+                message={message}
+              />
             </div>
           );
         }
@@ -63,10 +69,15 @@ const ChatContainer = ({ gatheringId }: ChatContainerProps) => {
             {isDifferentDay(createdAt, messages[index + 1].createdAt) ? (
               <div>
                 <ChatDate date={createdAt} />
-                <ChatBubble message={message} isFirstMessage />
+                <ChatBubble
+                  currentUserId={currentUserId}
+                  message={message}
+                  isFirstMessage
+                />
               </div>
             ) : (
               <ChatBubble
+                currentUserId={currentUserId}
                 message={message}
                 isFirstMessage={
                   messages[index + 1].type !== 'CHAT' ||

--- a/src/pages/ChatRoom/index.tsx
+++ b/src/pages/ChatRoom/index.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom';
 
+import { useGetChatRoomMessagesApi } from '@/apis/chatRoomMessages';
 import { useGetGatheringDetailApi } from '@/apis/gatheringDetail';
 import GatheringListItem from '@/components/GatheringListItem';
 import TabBar from '@/components/TabBar';
@@ -14,7 +15,17 @@ const ChatRoomPage = () => {
   };
   const gatheringId = parseInt(rawGatheringId, 10);
 
-  const { sendMessage } = useSendChatMessage(gatheringId, true);
+  const {
+    messages: rawMessages,
+    hasNextPage,
+    fetchNextPage,
+  } = useGetChatRoomMessagesApi(gatheringId, 20);
+
+  const { messages, sendMessage } = useSendChatMessage({
+    rawMessages,
+    gatheringId,
+    isPublishExitMessage: true,
+  });
   const { gatheringListItem } = useGetGatheringDetailApi(
     gatheringId.toString(),
   );
@@ -27,7 +38,11 @@ const ChatRoomPage = () => {
         </TabBar.Left>
       </TabBar.Container>
       <GatheringListItem gathering={gatheringListItem} />
-      <ChatContainer gatheringId={gatheringId} />
+      <ChatContainer
+        messages={messages}
+        hasNextPage={hasNextPage}
+        fetchNextPage={fetchNextPage}
+      />
       <ChatTextarea onSend={sendMessage} />
     </div>
   );

--- a/src/pages/GatheringDetail/hooks/useGatheringEntrance.ts
+++ b/src/pages/GatheringDetail/hooks/useGatheringEntrance.ts
@@ -5,7 +5,9 @@ import { showErrorToast } from '@/utils/showToast';
 
 export const useGatheringEntrance = (roomId: string) => {
   const postGatheringEntranceApi = usePostGatheringEntranceApi();
-  const { sendMessage } = useSendChatMessage(parseInt(roomId, 10));
+  const { sendMessage } = useSendChatMessage({
+    gatheringId: parseInt(roomId, 10),
+  });
 
   return async (onOpenModal: () => void) => {
     const { data, isOk, isBadRequest } = await postGatheringEntranceApi(roomId);

--- a/src/pages/GatheringDetail/hooks/useGatheringLeave.ts
+++ b/src/pages/GatheringDetail/hooks/useGatheringLeave.ts
@@ -5,7 +5,9 @@ import { showErrorToast } from '@/utils/showToast';
 
 export const useGatheringLeave = (roomId: string) => {
   const postGatheringLeaveApi = usePostGatheringLeaveApi();
-  const { sendMessage } = useSendChatMessage(parseInt(roomId, 10));
+  const { sendMessage } = useSendChatMessage({
+    gatheringId: parseInt(roomId, 10),
+  });
 
   return async (onOpenModal: () => void) => {
     const { data, isOk, isBadRequest } = await postGatheringLeaveApi(roomId);

--- a/src/pages/GatheringDetail/hooks/useKickParticipant.ts
+++ b/src/pages/GatheringDetail/hooks/useKickParticipant.ts
@@ -5,7 +5,9 @@ import { showErrorToast } from '@/utils/showToast';
 
 export const useKickParticipant = (gatheringId: number) => {
   const postKickParticipantApi = useKickParticipantApi(gatheringId);
-  const { sendMessage } = useSendChatMessage(gatheringId);
+  const { sendMessage } = useSendChatMessage({
+    gatheringId,
+  });
 
   return async (userId: number, onOpenModal: () => void) => {
     const { data, isOk, isBadRequest } = await postKickParticipantApi(userId);

--- a/src/pages/GatheringFix/GatheringFixForm/useGatheringFix.ts
+++ b/src/pages/GatheringFix/GatheringFixForm/useGatheringFix.ts
@@ -11,7 +11,9 @@ type OnGatheringFix = () => void;
 
 const useCreateGathering = (onCreate: OnGatheringFix, gatheringId: string) => {
   const gatheringCreateApi = usePostGatheringFix();
-  const { sendMessage } = useSendChatMessage(parseInt(gatheringId, 10));
+  const { sendMessage } = useSendChatMessage({
+    gatheringId: parseInt(gatheringId, 10),
+  });
 
   return async (request: GatheringFixRequest) => {
     const { data, isBadRequest } = await gatheringCreateApi({

--- a/src/pages/GatheringUnfix/hooks/useGatheringUnfix.ts
+++ b/src/pages/GatheringUnfix/hooks/useGatheringUnfix.ts
@@ -7,7 +7,9 @@ import type { OnGatheringUnfix } from '../components/GatheringUnfixForm';
 
 const useGatheringUnfix = (onUnfix: OnGatheringUnfix, gatheringId: string) => {
   const gatheringUnfixApi = useDeleteGatheringUnfixApi(gatheringId);
-  const { sendMessage } = useSendChatMessage(parseInt(gatheringId, 10));
+  const { sendMessage } = useSendChatMessage({
+    gatheringId: parseInt(gatheringId, 10),
+  });
 
   return async (reason: string) => {
     const { data, isBadRequest } = await gatheringUnfixApi({


### PR DESCRIPTION
## 💬 Issue Number

> closes #209 

## 🤷‍♂️ Description
채팅 목록, 채팅방 페이지에서 불필요한 API 호출을 제거했습니다.
- 새로운 메시지가 올 때마다 채팅 내역 불러오던 API 호출 제거
- 새로운 메시지가 올 때마다 sender를 구분하기 위해 로그인한 사용자 id를 받아오는 API 호출 제거
- 채팅 목록 페이지에서 최신 메시지, 읽지 않은 메시지를 채팅 목록 API 응답으로 내려 받으면서 추가적인 API 호출 제거

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
